### PR TITLE
Take dependency on Serilog-2.0.0-beta-505

### DIFF
--- a/sample/Sample/project.lock.json
+++ b/sample/Sample/project.lock.json
@@ -3,13 +3,12 @@
   "version": 2,
   "targets": {
     "DNX,Version=v4.5.1": {
-      "Serilog/2.0.0-beta-465": {
+      "Serilog/2.0.0-beta-505": {
         "type": "package",
         "frameworkAssemblies": [
           "Microsoft.CSharp",
           "mscorlib",
           "System",
-          "System.Configuration",
           "System.Core"
         ],
         "compile": {
@@ -19,10 +18,10 @@
           "lib/net45/Serilog.dll": {}
         }
       },
-      "Serilog.Sinks.File/2.0.0-beta-465": {
+      "Serilog.Sinks.File/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "Microsoft.CSharp",
@@ -31,15 +30,9 @@
           "System.Core"
         ],
         "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
           "lib/net45/Serilog.Sinks.File.dll": {}
         },
         "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
           "lib/net45/Serilog.Sinks.File.dll": {}
         }
       },
@@ -61,40 +54,10 @@
           "lib/net45/Serilog.Sinks.Literate.dll": {}
         }
       },
-      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-465": {
+      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465"
-        },
-        "frameworkAssemblies": [
-          "Microsoft.CSharp",
-          "mscorlib",
-          "System",
-          "System.Configuration",
-          "System.Core"
-        ],
-        "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
-        },
-        "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
-        }
-      },
-      "Serilog.Sinks.RollingFile/2.0.0-beta-465": {
-        "type": "package",
-        "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.File": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "Microsoft.CSharp",
@@ -103,31 +66,38 @@
           "System.Core"
         ],
         "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {},
+          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
+        }
+      },
+      "Serilog.Sinks.RollingFile/2.0.0-beta-505": {
+        "type": "package",
+        "dependencies": {
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.File": "2.0.0-beta-505"
+        },
+        "frameworkAssemblies": [
+          "Microsoft.CSharp",
+          "mscorlib",
+          "System",
+          "System.Core"
+        ],
+        "compile": {
           "lib/net45/Serilog.Sinks.RollingFile.dll": {}
         },
         "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {},
           "lib/net45/Serilog.Sinks.RollingFile.dll": {}
         }
       },
-      "Serilog.Sinks.Seq/2.0.0-beta": {
+      "Serilog.Sinks.Seq/2.0.0-beta-1": {
         "type": "project",
         "framework": ".NETFramework,Version=v4.5",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.PeriodicBatching": "2.0.0-beta-465",
-          "Serilog.Sinks.RollingFile": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.PeriodicBatching": "2.0.0-beta-505",
+          "Serilog.Sinks.RollingFile": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "System.Net.Http"
@@ -162,7 +132,7 @@
           "lib/dotnet5.4/Microsoft.CSharp.dll": {}
         }
       },
-      "Serilog/2.0.0-beta-465": {
+      "Serilog/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
           "Microsoft.CSharp": "4.0.1-beta-23516",
@@ -176,6 +146,7 @@
           "System.Linq": "4.0.1-beta-23516",
           "System.Reflection.Extensions": "4.0.1-beta-23516",
           "System.Runtime.Extensions": "4.0.11-beta-23516",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23516",
           "System.Text.RegularExpressions": "4.0.11-beta-23516",
           "System.Threading": "4.0.11-beta-23516",
           "System.Threading.Thread": "4.0.0-beta-23516"
@@ -187,24 +158,18 @@
           "lib/dotnet5.4/Serilog.dll": {}
         }
       },
-      "Serilog.Sinks.File/2.0.0-beta-465": {
+      "Serilog.Sinks.File/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
           "System.IO": "4.0.11-beta-23516",
           "System.IO.FileSystem": "4.0.0",
           "System.IO.FileSystem.Primitives": "4.0.0"
         },
         "compile": {
-          "lib/dotnet5.1/Serilog.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.Console.dll": {},
           "lib/dotnet5.1/Serilog.Sinks.File.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.1/Serilog.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.Console.dll": {},
           "lib/dotnet5.1/Serilog.Sinks.File.dll": {}
         }
       },
@@ -221,45 +186,41 @@
           "lib/dotnet5.1/Serilog.Sinks.Literate.dll": {}
         }
       },
-      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-465": {
+      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
           "System.Collections.Concurrent": "4.0.11-beta-23516"
         },
         "compile": {
-          "lib/dotnet5.2/Serilog.Sinks.Observable.dll": {},
           "lib/dotnet5.2/Serilog.Sinks.PeriodicBatching.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.2/Serilog.Sinks.Observable.dll": {},
           "lib/dotnet5.2/Serilog.Sinks.PeriodicBatching.dll": {}
         }
       },
-      "Serilog.Sinks.RollingFile/2.0.0-beta-465": {
+      "Serilog.Sinks.RollingFile/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.File": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.File": "2.0.0-beta-505",
           "System.IO": "4.0.11-beta-23516",
           "System.IO.FileSystem.Primitives": "4.0.1-beta-23516"
         },
         "compile": {
-          "lib/dotnet5.4/Serilog.dll": {},
           "lib/dotnet5.4/Serilog.Sinks.RollingFile.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.4/Serilog.dll": {},
           "lib/dotnet5.4/Serilog.Sinks.RollingFile.dll": {}
         }
       },
-      "Serilog.Sinks.Seq/2.0.0-beta": {
+      "Serilog.Sinks.Seq/2.0.0-beta-1": {
         "type": "project",
         "framework": ".NETPlatform,Version=v5.4",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.PeriodicBatching": "2.0.0-beta-465",
-          "Serilog.Sinks.RollingFile": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.PeriodicBatching": "2.0.0-beta-505",
+          "Serilog.Sinks.RollingFile": "2.0.0-beta-505",
           "System.Net.Http": "4.0.1-beta-23516"
         }
       },
@@ -598,6 +559,19 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
+      "System.Runtime.Serialization.Primitives/4.1.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
+        }
+      },
       "System.Text.Encoding/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -660,13 +634,12 @@
       }
     },
     "DNX,Version=v4.5.1/win7-x86": {
-      "Serilog/2.0.0-beta-465": {
+      "Serilog/2.0.0-beta-505": {
         "type": "package",
         "frameworkAssemblies": [
           "Microsoft.CSharp",
           "mscorlib",
           "System",
-          "System.Configuration",
           "System.Core"
         ],
         "compile": {
@@ -676,10 +649,10 @@
           "lib/net45/Serilog.dll": {}
         }
       },
-      "Serilog.Sinks.File/2.0.0-beta-465": {
+      "Serilog.Sinks.File/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "Microsoft.CSharp",
@@ -688,15 +661,9 @@
           "System.Core"
         ],
         "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
           "lib/net45/Serilog.Sinks.File.dll": {}
         },
         "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
           "lib/net45/Serilog.Sinks.File.dll": {}
         }
       },
@@ -718,40 +685,10 @@
           "lib/net45/Serilog.Sinks.Literate.dll": {}
         }
       },
-      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-465": {
+      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465"
-        },
-        "frameworkAssemblies": [
-          "Microsoft.CSharp",
-          "mscorlib",
-          "System",
-          "System.Configuration",
-          "System.Core"
-        ],
-        "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
-        },
-        "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
-        }
-      },
-      "Serilog.Sinks.RollingFile/2.0.0-beta-465": {
-        "type": "package",
-        "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.File": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "Microsoft.CSharp",
@@ -760,31 +697,38 @@
           "System.Core"
         ],
         "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {},
+          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
+        }
+      },
+      "Serilog.Sinks.RollingFile/2.0.0-beta-505": {
+        "type": "package",
+        "dependencies": {
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.File": "2.0.0-beta-505"
+        },
+        "frameworkAssemblies": [
+          "Microsoft.CSharp",
+          "mscorlib",
+          "System",
+          "System.Core"
+        ],
+        "compile": {
           "lib/net45/Serilog.Sinks.RollingFile.dll": {}
         },
         "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {},
           "lib/net45/Serilog.Sinks.RollingFile.dll": {}
         }
       },
-      "Serilog.Sinks.Seq/2.0.0-beta": {
+      "Serilog.Sinks.Seq/2.0.0-beta-1": {
         "type": "project",
         "framework": ".NETFramework,Version=v4.5",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.PeriodicBatching": "2.0.0-beta-465",
-          "Serilog.Sinks.RollingFile": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.PeriodicBatching": "2.0.0-beta-505",
+          "Serilog.Sinks.RollingFile": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "System.Net.Http"
@@ -792,13 +736,12 @@
       }
     },
     "DNX,Version=v4.5.1/win7-x64": {
-      "Serilog/2.0.0-beta-465": {
+      "Serilog/2.0.0-beta-505": {
         "type": "package",
         "frameworkAssemblies": [
           "Microsoft.CSharp",
           "mscorlib",
           "System",
-          "System.Configuration",
           "System.Core"
         ],
         "compile": {
@@ -808,10 +751,10 @@
           "lib/net45/Serilog.dll": {}
         }
       },
-      "Serilog.Sinks.File/2.0.0-beta-465": {
+      "Serilog.Sinks.File/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "Microsoft.CSharp",
@@ -820,15 +763,9 @@
           "System.Core"
         ],
         "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
           "lib/net45/Serilog.Sinks.File.dll": {}
         },
         "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
           "lib/net45/Serilog.Sinks.File.dll": {}
         }
       },
@@ -850,40 +787,10 @@
           "lib/net45/Serilog.Sinks.Literate.dll": {}
         }
       },
-      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-465": {
+      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465"
-        },
-        "frameworkAssemblies": [
-          "Microsoft.CSharp",
-          "mscorlib",
-          "System",
-          "System.Configuration",
-          "System.Core"
-        ],
-        "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
-        },
-        "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
-        }
-      },
-      "Serilog.Sinks.RollingFile/2.0.0-beta-465": {
-        "type": "package",
-        "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.File": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "Microsoft.CSharp",
@@ -892,31 +799,38 @@
           "System.Core"
         ],
         "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {},
+          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
+        }
+      },
+      "Serilog.Sinks.RollingFile/2.0.0-beta-505": {
+        "type": "package",
+        "dependencies": {
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.File": "2.0.0-beta-505"
+        },
+        "frameworkAssemblies": [
+          "Microsoft.CSharp",
+          "mscorlib",
+          "System",
+          "System.Core"
+        ],
+        "compile": {
           "lib/net45/Serilog.Sinks.RollingFile.dll": {}
         },
         "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {},
           "lib/net45/Serilog.Sinks.RollingFile.dll": {}
         }
       },
-      "Serilog.Sinks.Seq/2.0.0-beta": {
+      "Serilog.Sinks.Seq/2.0.0-beta-1": {
         "type": "project",
         "framework": ".NETFramework,Version=v4.5",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.PeriodicBatching": "2.0.0-beta-465",
-          "Serilog.Sinks.RollingFile": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.PeriodicBatching": "2.0.0-beta-505",
+          "Serilog.Sinks.RollingFile": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "System.Net.Http"
@@ -1128,7 +1042,7 @@
           "runtimes/win7/lib/DNXCore50/System.Threading.dll": {}
         }
       },
-      "Serilog/2.0.0-beta-465": {
+      "Serilog/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
           "Microsoft.CSharp": "4.0.1-beta-23516",
@@ -1142,6 +1056,7 @@
           "System.Linq": "4.0.1-beta-23516",
           "System.Reflection.Extensions": "4.0.1-beta-23516",
           "System.Runtime.Extensions": "4.0.11-beta-23516",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23516",
           "System.Text.RegularExpressions": "4.0.11-beta-23516",
           "System.Threading": "4.0.11-beta-23516",
           "System.Threading.Thread": "4.0.0-beta-23516"
@@ -1153,24 +1068,18 @@
           "lib/dotnet5.4/Serilog.dll": {}
         }
       },
-      "Serilog.Sinks.File/2.0.0-beta-465": {
+      "Serilog.Sinks.File/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
           "System.IO": "4.0.11-beta-23516",
           "System.IO.FileSystem": "4.0.0",
           "System.IO.FileSystem.Primitives": "4.0.0"
         },
         "compile": {
-          "lib/dotnet5.1/Serilog.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.Console.dll": {},
           "lib/dotnet5.1/Serilog.Sinks.File.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.1/Serilog.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.Console.dll": {},
           "lib/dotnet5.1/Serilog.Sinks.File.dll": {}
         }
       },
@@ -1187,45 +1096,41 @@
           "lib/dotnet5.1/Serilog.Sinks.Literate.dll": {}
         }
       },
-      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-465": {
+      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
           "System.Collections.Concurrent": "4.0.11-beta-23516"
         },
         "compile": {
-          "lib/dotnet5.2/Serilog.Sinks.Observable.dll": {},
           "lib/dotnet5.2/Serilog.Sinks.PeriodicBatching.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.2/Serilog.Sinks.Observable.dll": {},
           "lib/dotnet5.2/Serilog.Sinks.PeriodicBatching.dll": {}
         }
       },
-      "Serilog.Sinks.RollingFile/2.0.0-beta-465": {
+      "Serilog.Sinks.RollingFile/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.File": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.File": "2.0.0-beta-505",
           "System.IO": "4.0.11-beta-23516",
           "System.IO.FileSystem.Primitives": "4.0.1-beta-23516"
         },
         "compile": {
-          "lib/dotnet5.4/Serilog.dll": {},
           "lib/dotnet5.4/Serilog.Sinks.RollingFile.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.4/Serilog.dll": {},
           "lib/dotnet5.4/Serilog.Sinks.RollingFile.dll": {}
         }
       },
-      "Serilog.Sinks.Seq/2.0.0-beta": {
+      "Serilog.Sinks.Seq/2.0.0-beta-1": {
         "type": "project",
         "framework": ".NETPlatform,Version=v5.4",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.PeriodicBatching": "2.0.0-beta-465",
-          "Serilog.Sinks.RollingFile": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.PeriodicBatching": "2.0.0-beta-505",
+          "Serilog.Sinks.RollingFile": "2.0.0-beta-505",
           "System.Net.Http": "4.0.1-beta-23516"
         }
       },
@@ -1582,6 +1487,19 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Runtime.Serialization.Primitives/4.1.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
         }
       },
       "System.Security.Cryptography.Algorithms/4.0.0-beta-23516": {
@@ -1942,7 +1860,7 @@
           "runtimes/win7/lib/DNXCore50/System.Threading.dll": {}
         }
       },
-      "Serilog/2.0.0-beta-465": {
+      "Serilog/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
           "Microsoft.CSharp": "4.0.1-beta-23516",
@@ -1956,6 +1874,7 @@
           "System.Linq": "4.0.1-beta-23516",
           "System.Reflection.Extensions": "4.0.1-beta-23516",
           "System.Runtime.Extensions": "4.0.11-beta-23516",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23516",
           "System.Text.RegularExpressions": "4.0.11-beta-23516",
           "System.Threading": "4.0.11-beta-23516",
           "System.Threading.Thread": "4.0.0-beta-23516"
@@ -1967,24 +1886,18 @@
           "lib/dotnet5.4/Serilog.dll": {}
         }
       },
-      "Serilog.Sinks.File/2.0.0-beta-465": {
+      "Serilog.Sinks.File/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
           "System.IO": "4.0.11-beta-23516",
           "System.IO.FileSystem": "4.0.0",
           "System.IO.FileSystem.Primitives": "4.0.0"
         },
         "compile": {
-          "lib/dotnet5.1/Serilog.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.Console.dll": {},
           "lib/dotnet5.1/Serilog.Sinks.File.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.1/Serilog.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.Console.dll": {},
           "lib/dotnet5.1/Serilog.Sinks.File.dll": {}
         }
       },
@@ -2001,45 +1914,41 @@
           "lib/dotnet5.1/Serilog.Sinks.Literate.dll": {}
         }
       },
-      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-465": {
+      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
           "System.Collections.Concurrent": "4.0.11-beta-23516"
         },
         "compile": {
-          "lib/dotnet5.2/Serilog.Sinks.Observable.dll": {},
           "lib/dotnet5.2/Serilog.Sinks.PeriodicBatching.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.2/Serilog.Sinks.Observable.dll": {},
           "lib/dotnet5.2/Serilog.Sinks.PeriodicBatching.dll": {}
         }
       },
-      "Serilog.Sinks.RollingFile/2.0.0-beta-465": {
+      "Serilog.Sinks.RollingFile/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.File": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.File": "2.0.0-beta-505",
           "System.IO": "4.0.11-beta-23516",
           "System.IO.FileSystem.Primitives": "4.0.1-beta-23516"
         },
         "compile": {
-          "lib/dotnet5.4/Serilog.dll": {},
           "lib/dotnet5.4/Serilog.Sinks.RollingFile.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.4/Serilog.dll": {},
           "lib/dotnet5.4/Serilog.Sinks.RollingFile.dll": {}
         }
       },
-      "Serilog.Sinks.Seq/2.0.0-beta": {
+      "Serilog.Sinks.Seq/2.0.0-beta-1": {
         "type": "project",
         "framework": ".NETPlatform,Version=v5.4",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.PeriodicBatching": "2.0.0-beta-465",
-          "Serilog.Sinks.RollingFile": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.PeriodicBatching": "2.0.0-beta-505",
+          "Serilog.Sinks.RollingFile": "2.0.0-beta-505",
           "System.Net.Http": "4.0.1-beta-23516"
         }
       },
@@ -2398,6 +2307,19 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
+      "System.Runtime.Serialization.Primitives/4.1.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
+        }
+      },
       "System.Security.Cryptography.Algorithms/4.0.0-beta-23516": {
         "type": "package",
         "dependencies": {
@@ -2553,14 +2475,14 @@
     }
   },
   "libraries": {
-    "Serilog.Sinks.Seq/2.0.0-beta": {
+    "Serilog.Sinks.Seq/2.0.0-beta-1": {
       "type": "project",
       "path": "../../src/Serilog.Sinks.Seq/project.json"
     },
     "Microsoft.CSharp/4.0.1-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fb+HO3nIjHao9lqsVVM0ne3GM/+1EfRQUoM58cxEOt+5biy/8DQ1nxIahZ9VaJKw7Wgb6XhRhsdwg8DkePEOJA==",
+      "sha512": "z/W5YaTGVQ8WX6TQDW8cCBAe2rBhHOD7NZHxLAnBIMoLWMI/upWDi+dxHYMDDWmGOM7a3di6evem2OzOdaB1fQ==",
       "files": [
         "lib/dotnet5.4/Microsoft.CSharp.dll",
         "lib/MonoAndroid10/_._",
@@ -2642,7 +2564,7 @@
     "Microsoft.Win32.Registry/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "z54NYVj7y4jGC2EWn5QLqaokMOws5NAjZYbEgUDNCtJE5gkpRR1JnDWU1Kjuvu3mmro2K9/C1TposmHB8cAtmg==",
+      "sha512": "1UxMko0bXvk98vNVwbgHNZ+soSvK4LXy9nMUYW67MHdZXAfp0hbJIMj6MnRpMoKExZLCz6a7/0Kq112y+sbGxQ==",
       "files": [
         "lib/DNXCore50/Microsoft.Win32.Registry.dll",
         "lib/net46/Microsoft.Win32.Registry.dll",
@@ -2666,7 +2588,7 @@
     "runtime.win7.System.Console/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "pfQrTtnYcWOtI3RrpqjAzwT3I55ivTVZFpbKYG59dYTTvaLFGbs2njc/mrXHij6GylyJ2YjekS/9r6I8X3LV1A==",
+      "sha512": "TJZhrw44Bf7sYqne+CX5II/PaNf5L7oKVfl0FLkr4pj76KS8hSsJzsKL0IvxC+bi4d51+wTbv91kF1kgPyHMVw==",
       "files": [
         "ref/dotnet/_._",
         "runtime.win7.System.Console.4.0.0-beta-23516.nupkg",
@@ -2679,7 +2601,7 @@
     "runtime.win7.System.Diagnostics.Process/4.1.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "qCCXX+OG6430kLtN/wyjeLTTiJvOIKB2G+qBvhSqVLWe5ZTiEiSnweKUzdi7raXL0te0WfPE5tf8FuKcEKPnIA==",
+      "sha512": "IDp4dljG6NkpMP9UzrtuvLZ0wfeOHphStOsVLmUTj2g3UH28L5Lo9481/fAXVPs2GEVMRwAvSwph90EcNfV/jQ==",
       "files": [
         "ref/dotnet/_._",
         "runtime.win7.System.Diagnostics.Process.4.1.0-beta-23516.nupkg",
@@ -2696,7 +2618,7 @@
     "runtime.win7.System.Diagnostics.TraceSource/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "hpD0T6zOEU/1qUSPitKSgIdsL4tZlZz7CUCu6PP7BYf8CM3vPkSEzN38kX6PnH8F6kvOqxEwzPYhZCK3PJkh/Q==",
+      "sha512": "6YSh7+vRI2ptFNPTWE100MNz0sRAVuBjwU0znK3kzd5GYQgLjvtWn8rT9DvJQA4R6OmC5Q+OgXzb/nibxcbtbA==",
       "files": [
         "ref/dotnet/_._",
         "runtime.win7.System.Diagnostics.TraceSource.4.0.0-beta-23516.nupkg",
@@ -2713,7 +2635,7 @@
     "runtime.win7.System.IO.FileSystem/4.0.1-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "UOHEVg3jQwsvy3b+8zhDk7BQ9GhHY1KcjHSuqArzIl7oemcM/+D7OfS5iOA96ydjEv9FmIKV3knkXMge+cUD0Q==",
+      "sha512": "PwsqcwAui7Ld6Ad32RjoHF3wBSEkEzvv5ka605IsaWxHSCfmmwevJnIbNgwJgBTao/uR+wSO9yoyvfrB109BfQ==",
       "files": [
         "ref/dotnet/_._",
         "runtime.win7.System.IO.FileSystem.4.0.1-beta-23516.nupkg",
@@ -2743,7 +2665,7 @@
     "runtime.win7.System.Private.Uri/4.0.1-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "HphDhue34J/4+1rIMtInY1FWK1oLEMpxIpxGeNnhIlQf7hv5QDf05aWEC6180qbgkPBCFwyGnwWRBnONApwbBQ==",
+      "sha512": "dENjtxxx1L+OXWnxGRzeAD8mJC//NljPPLXNWg1H5BG6IB4YTLzBSzfeCOZQVpQaKfCYE7Mzjq12uCVZpBG4vg==",
       "files": [
         "ref/dotnet/_._",
         "runtime.win7.System.Private.Uri.4.0.1-beta-23516.nupkg",
@@ -2757,7 +2679,7 @@
     "runtime.win7.System.Runtime.Extensions/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Jm+LAzN7CZl1BZSxz4TsMBNy1rHNqyY/1+jxZf3BpF7vkPlWRXa/vSfY0lZJZdy4Doxa893bmcCf9pZNsJU16Q==",
+      "sha512": "V4HbLYv2m4LaL+Kl+x6wz8Xl9TyrHBpA/lYq+w6J35mYY9ACCVV+YkHRJdNuRd3Qe3DEz9X8D1S8uWnKMyHvvg==",
       "files": [
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/netcore50/System.Runtime.Extensions.dll",
@@ -2771,7 +2693,7 @@
     "runtime.win7.System.Threading/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "paSNXQ5Y6Exu3OpekooyMJFQ8mitn69fGO5Br3XLIfQ1KiMYVmRf+o6dMprC0SpPROVCiCxdUaJx5XkDEVL3uA==",
+      "sha512": "kKQ9uUB1g3S9eyK5njdwh5LO0HxJ9CN6cF9dXtp7uzdZvh2UoTgAZ0Jf+/TvzWcUsfcKIPQUGPPLOBLaQpXASg==",
       "files": [
         "ref/dotnet/_._",
         "runtime.win7.System.Threading.4.0.11-beta-23516.nupkg",
@@ -2782,45 +2704,31 @@
         "runtimes/win8-aot/lib/netcore50/System.Threading.dll"
       ]
     },
-    "Serilog/2.0.0-beta-465": {
+    "Serilog/2.0.0-beta-505": {
       "type": "package",
-      "sha512": "WCWljYsF2u2gzcKAAieKisqI4GXfd1Y97jfOa+yfqfLhur0VOt/20SwEQprOBfpSdlKbDbefSg9PjaLB0HzR6A==",
+      "sha512": "Pp8dfTjdUfYkwRGi3Ukxxxx+gJxnVeXO1TA6U3uISCcymKZLCkV1pHHwbZA8XjroTOV4a4Jzim9NK7zyab/lZQ==",
       "files": [
         "lib/dotnet5.1/Serilog.dll",
         "lib/dotnet5.1/Serilog.xml",
         "lib/dotnet5.4/Serilog.dll",
         "lib/dotnet5.4/Serilog.xml",
-        "lib/net40/Serilog.dll",
-        "lib/net40/Serilog.xml",
         "lib/net45/Serilog.dll",
         "lib/net45/Serilog.xml",
-        "Serilog.2.0.0-beta-465.nupkg",
-        "Serilog.2.0.0-beta-465.nupkg.sha512",
+        "Serilog.2.0.0-beta-505.nupkg",
+        "Serilog.2.0.0-beta-505.nupkg.sha512",
         "Serilog.nuspec"
       ]
     },
-    "Serilog.Sinks.File/2.0.0-beta-465": {
+    "Serilog.Sinks.File/2.0.0-beta-505": {
       "type": "package",
-      "sha512": "FVLlr0971K7AEiDIMEMNxEsfqIHxvOakD4PjlpNKl0IhGP+ZX5DX9pCFENta7jTe7KU4vz3MVWvo7GDmdHamaQ==",
+      "sha512": "COA3V43z40MdSP3c0pXZX6SadoxgH6QckcNL332dgcnisCgw6kEDVzS7p89P+/+3keyYye6vDHkSTE09Khv7kQ==",
       "files": [
-        "lib/dotnet5.1/Serilog.dll",
-        "lib/dotnet5.1/Serilog.Sinks.ColoredConsole.dll",
-        "lib/dotnet5.1/Serilog.Sinks.ColoredConsole.xml",
-        "lib/dotnet5.1/Serilog.Sinks.Console.dll",
-        "lib/dotnet5.1/Serilog.Sinks.Console.xml",
         "lib/dotnet5.1/Serilog.Sinks.File.dll",
         "lib/dotnet5.1/Serilog.Sinks.File.xml",
-        "lib/dotnet5.1/Serilog.xml",
-        "lib/net45/Serilog.dll",
-        "lib/net45/Serilog.Sinks.ColoredConsole.dll",
-        "lib/net45/Serilog.Sinks.ColoredConsole.xml",
-        "lib/net45/Serilog.Sinks.Console.dll",
-        "lib/net45/Serilog.Sinks.Console.xml",
         "lib/net45/Serilog.Sinks.File.dll",
         "lib/net45/Serilog.Sinks.File.xml",
-        "lib/net45/Serilog.xml",
-        "Serilog.Sinks.File.2.0.0-beta-465.nupkg",
-        "Serilog.Sinks.File.2.0.0-beta-465.nupkg.sha512",
+        "Serilog.Sinks.File.2.0.0-beta-505.nupkg",
+        "Serilog.Sinks.File.2.0.0-beta-505.nupkg.sha512",
         "Serilog.Sinks.File.nuspec"
       ]
     },
@@ -2837,62 +2745,36 @@
         "Serilog.Sinks.Literate.nuspec"
       ]
     },
-    "Serilog.Sinks.PeriodicBatching/2.0.0-beta-465": {
+    "Serilog.Sinks.PeriodicBatching/2.0.0-beta-505": {
       "type": "package",
-      "sha512": "KPtLMJfGhsGNkaluN43CRisEqIoOjhpNZdr4NmbOLvPhKauD7deO8n9gwiC7Bmh5ZV8pz2ilaerJ1QY/r+ggDg==",
+      "sha512": "5r8Lh4UW+YNMbIzown4moCLEAPEB/Wo7ug0I5Fd8Tjc6G4398NJqzLJgK2IIShcYsqAmIZiM+pl+ll6gdP1piQ==",
       "files": [
-        "lib/dotnet5.2/Serilog.Sinks.Observable.dll",
-        "lib/dotnet5.2/Serilog.Sinks.Observable.xml",
         "lib/dotnet5.2/Serilog.Sinks.PeriodicBatching.dll",
         "lib/dotnet5.2/Serilog.Sinks.PeriodicBatching.xml",
-        "lib/net45/Serilog.dll",
-        "lib/net45/Serilog.Sinks.ColoredConsole.dll",
-        "lib/net45/Serilog.Sinks.ColoredConsole.xml",
-        "lib/net45/Serilog.Sinks.Console.dll",
-        "lib/net45/Serilog.Sinks.Console.xml",
-        "lib/net45/Serilog.Sinks.File.dll",
-        "lib/net45/Serilog.Sinks.File.xml",
-        "lib/net45/Serilog.Sinks.Observable.dll",
-        "lib/net45/Serilog.Sinks.Observable.xml",
         "lib/net45/Serilog.Sinks.PeriodicBatching.dll",
         "lib/net45/Serilog.Sinks.PeriodicBatching.xml",
-        "lib/net45/Serilog.xml",
-        "Serilog.Sinks.PeriodicBatching.2.0.0-beta-465.nupkg",
-        "Serilog.Sinks.PeriodicBatching.2.0.0-beta-465.nupkg.sha512",
+        "Serilog.Sinks.PeriodicBatching.2.0.0-beta-505.nupkg",
+        "Serilog.Sinks.PeriodicBatching.2.0.0-beta-505.nupkg.sha512",
         "Serilog.Sinks.PeriodicBatching.nuspec"
       ]
     },
-    "Serilog.Sinks.RollingFile/2.0.0-beta-465": {
+    "Serilog.Sinks.RollingFile/2.0.0-beta-505": {
       "type": "package",
-      "sha512": "CLY7hvQCnCYZ9kCFrsgg9VWoMwM3MKv8M78PPbRNxl/uT/BTzH3uQNfPkQnO3SizbvWKrDquubxoWqwS/L/0Hw==",
+      "sha512": "1mSt+NBL2a9xFcJ36atukRLzqHSXtiaREJM8sgF5/0Rc2+HSDWimpLmmrV2qijBe5jPVBHB1ojxQGLbArPeexQ==",
       "files": [
-        "lib/dotnet5.4/Serilog.dll",
         "lib/dotnet5.4/Serilog.Sinks.RollingFile.dll",
         "lib/dotnet5.4/Serilog.Sinks.RollingFile.xml",
-        "lib/dotnet5.4/Serilog.xml",
-        "lib/net45/Serilog.dll",
-        "lib/net45/Serilog.Sinks.ColoredConsole.dll",
-        "lib/net45/Serilog.Sinks.ColoredConsole.xml",
-        "lib/net45/Serilog.Sinks.Console.dll",
-        "lib/net45/Serilog.Sinks.Console.xml",
-        "lib/net45/Serilog.Sinks.File.dll",
-        "lib/net45/Serilog.Sinks.File.xml",
-        "lib/net45/Serilog.Sinks.Observable.dll",
-        "lib/net45/Serilog.Sinks.Observable.xml",
-        "lib/net45/Serilog.Sinks.PeriodicBatching.dll",
-        "lib/net45/Serilog.Sinks.PeriodicBatching.xml",
         "lib/net45/Serilog.Sinks.RollingFile.dll",
         "lib/net45/Serilog.Sinks.RollingFile.xml",
-        "lib/net45/Serilog.xml",
-        "Serilog.Sinks.RollingFile.2.0.0-beta-465.nupkg",
-        "Serilog.Sinks.RollingFile.2.0.0-beta-465.nupkg.sha512",
+        "Serilog.Sinks.RollingFile.2.0.0-beta-505.nupkg",
+        "Serilog.Sinks.RollingFile.2.0.0-beta-505.nupkg.sha512",
         "Serilog.Sinks.RollingFile.nuspec"
       ]
     },
     "System.Collections/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "TDca4OETV0kkXdpkyivMw1/EKKD1Sa/NVAjirw+fA0LZ37jLDYX+KhPPUQxgkvhCe/SVvxETD5Viiudza2k7OQ==",
+      "sha512": "FSd5zsGfmG2pidC3CVizQPNGTK1Q3A2HEuRqwUPLU/AArjELLC5p4l6XIAlJ9ZBPdbp6V8vFQAxUHzkFfyVkYA==",
       "files": [
         "lib/DNXCore50/System.Collections.dll",
         "lib/MonoAndroid10/_._",
@@ -2954,7 +2836,7 @@
     "System.Collections.Concurrent/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "e4FscEk9ugPXPKEIQFYBS/i+0KAkKf/IEe26fiOnqk8JVZQuCLO3gJmJ+IiVD1TxJjvVmh+tayQuo2svVzZV7g==",
+      "sha512": "K+n6bC3jL5nRzwm8IM5WHxPScCnrVoPCJjpkBEmoBYY8/3j4RJdqIng/NYcpGcjvP/GIF6tAwZlh54ao2pWOvQ==",
       "files": [
         "lib/dotnet5.4/System.Collections.Concurrent.dll",
         "lib/MonoAndroid10/_._",
@@ -3013,7 +2895,7 @@
     "System.Console/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "0YTzoNamTU+6qfZEYtMuGjtkJHB1MEDyFsZ5L/x97GkZO3Bw91uwdPh0DkFwQ6E8KaQTgZAecSXoboUHAcdSLA==",
+      "sha512": "tzF4Dbbv+5bcbQ7GHuuKafkaDZThiUiwxqCc1ngewnMWZ5YmIgjQZjs+E1DNhoMVAvkH0tSmLJvsDlx9dFg+Aw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3124,7 +3006,7 @@
     "System.Diagnostics.TraceSource/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OIWB5pvMqOdCraAtiJBhRahrsnP2sNaXbCZNdAadzwiPLzRI7EvLTc7/NlkFDxm3I6YKVGxnJ5aO+YJ/XPC8yw==",
+      "sha512": "gvJNxObthiaV07AKZYjQV69xRBKRR7gTpEVe4qXF4Mta/2zD7sI+Zm//rRCQenLYBuL8nBxVzomtYJ4eT7w8QQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3238,7 +3120,7 @@
     "System.Globalization/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "htoF4cS3WhCkU3HloMj3mz+h2FHnF8Hz0po/26otT5e46LlJ8p7LpFpxckxVviyYg9Fab9gr8aIB0ZDN9Cjpig==",
+      "sha512": "jctanC1VveBFsgOysiqFN/HH0qX+EvLNelcBU6Fb4w7m3BBu827k8RCNiwW+uAC5f5XZBTRpsXZk4cI15RCdYQ==",
       "files": [
         "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
@@ -3300,7 +3182,7 @@
     "System.IO/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "dR1DaWrF0zsV2z/GVs8xVvMds6xu0ykuwv+VPou8wbpJ1XxGBK9g6v5F84DWL8Q1qi+6Kyb56wbZYdYQO8OMew==",
+      "sha512": "6nJmAk4vYjN+5/haenkKk/BDGCOKw5pk5EjXAOvBnUM5PFIfO8JwUxGbcveOD4vV5Vb6TAxrmRmts/7F+BEuEw==",
       "files": [
         "lib/DNXCore50/System.IO.dll",
         "lib/MonoAndroid10/_._",
@@ -3402,7 +3284,7 @@
     "System.IO.FileSystem/4.0.1-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "KOYNQ6FeLQh0HdHVlp6IRjRGPCjyFvZRKfhYSDFi7DR0EHY3cC2rvfVj5HWJEW5KlSaa01Ct25m06yVnqSxwOQ==",
+      "sha512": "xggWMgLzKnBisYTx5HW3og8qRR7TjmorQAdsAQOaMcY4I9CQA6JUxw0r2AvCC1+ToXh0CuO7J6dymX33pkmwbA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3466,7 +3348,7 @@
     "System.Linq/4.0.1-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "uNxm2RB+kMeiKnY26iPvOtJLzTzNaAF4A2qqyzev6j8x8w2Dr+gg7LF7BHCwC55N7OirhHrAWUb3C0n4oi9qYw==",
+      "sha512": "AJaoyeAHLpurbTWnmvOhK/QC2sswKJrIA5RlPea+UdfXpHOw3srPNEPpseZDMV/EviVqAwUfFNkc5QxpGZtsLA==",
       "files": [
         "lib/dotnet5.4/System.Linq.dll",
         "lib/net45/_._",
@@ -3672,7 +3554,7 @@
     },
     "System.Private.Uri/4.0.1-beta-23516": {
       "type": "package",
-      "sha512": "MG79ArOc8KhfAkjrimI5GFH4tML7XFo+Z1sEQGLPxrBlwfbITwrrNfYb3YoH6CpAlJHc4pcs/gZrUas/pEkTdg==",
+      "sha512": "PISxTW5FSZw8cQ8DOvq2pHHz48mok3ex0/QU2gcHG5PACvobxaXQl2oR345vqOx6C15l10bJPVkKZlgi2Ic4KQ==",
       "files": [
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
@@ -3718,7 +3600,7 @@
     "System.Reflection.Extensions/4.0.1-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "CiaYbkU2dzOSTSB7X/xLvlae3rop8xz62XjflUSnyCaRPB5XaQR4JasHW07/lRKJowt67Km7K1LMpYEmoRku8w==",
+      "sha512": "Ph0ELqqqz218bGEtnfQ1xegANVQ3v0S/hU12AHpb4HEw8SESssbNCKWEVjeI3y2xDYaVx1aVjM4hZ1QXa4IonQ==",
       "files": [
         "lib/DNXCore50/System.Reflection.Extensions.dll",
         "lib/net45/_._",
@@ -3863,7 +3745,7 @@
     "System.Runtime/4.0.21-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "R174ctQjJnCIVxA2Yzp1v68wfLfPSROZWrbaSBcnEzHAQbOjprBQi37aWdr5y05Pq2J/O7h6SjTsYhVOLdiRYQ==",
+      "sha512": "ToYWwDgwR8fR9/8aaV+7PMFBfG2tEgGWED0l9OC9DQieaKEMAzXV3c6fOkK8FTd9YPjFcYnvx73tg21w6GuNDA==",
       "files": [
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
@@ -3936,7 +3818,7 @@
     "System.Runtime.Extensions/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "HX4wNPrcCV9D+jpbsJCRPuVJbcDM+JobSotQWKq40lCq0WJbJi+0lNQ/T1zHEdWcf4W2PmtMkug1rW7yKW9PiQ==",
+      "sha512": "mpKQVIySlFSvgQkeb9qvXxHOY3jV7H9x5DmPSeNac0APFOG9ROufrMozY3VP/GxBWu4AVS/HDG1lUxg/riE4ew==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -4061,10 +3943,71 @@
         "System.Runtime.InteropServices.nuspec"
       ]
     },
+    "System.Runtime.Serialization.Primitives/4.1.0-beta-23516": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "Dsl95PE2vyGIy9voclfTVKSqYD8O4PjsMS+TV0bM3N1xNraS2BBaChGk1stGmf04cn2/xA3cZyh80bkZL+v1/Q==",
+      "files": [
+        "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/System.Runtime.Serialization.Primitives.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet5.1/de/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/es/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/fr/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/it/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/ja/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/ko/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/ru/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/System.Runtime.Serialization.Primitives.dll",
+        "ref/dotnet5.1/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/zh-hans/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/zh-hant/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/de/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/es/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/fr/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/it/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/ja/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/ko/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/ru/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/System.Runtime.Serialization.Primitives.dll",
+        "ref/dotnet5.4/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/zh-hans/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/zh-hant/System.Runtime.Serialization.Primitives.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/es/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/fr/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/it/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/ja/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/ko/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/ru/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/System.Runtime.Serialization.Primitives.dll",
+        "ref/netcore50/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/zh-hans/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/zh-hant/System.Runtime.Serialization.Primitives.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Runtime.Serialization.Primitives.4.1.0-beta-23516.nupkg",
+        "System.Runtime.Serialization.Primitives.4.1.0-beta-23516.nupkg.sha512",
+        "System.Runtime.Serialization.Primitives.nuspec"
+      ]
+    },
     "System.Security.Cryptography.Algorithms/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "yvMpzC6Cd/UBHB3LU4z4jorW8nuitQfG171R8INxoUtNTZPBUmVhW4MW4adQYmwZ9IJ5C5rxnXKNfsvF5g9eog==",
+      "sha512": "h0t6XvR47THFihonJfk2aC3m2YQ94hzF0bFBE9Zgs4td+G+NgIuRmIdGQMFKv3sH7jX5ItOLq/K7uX9M6dvlgQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -4086,7 +4029,7 @@
     "System.Security.Cryptography.Encoding/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "UQxu43zAZI+UIaiUCrBKnmF4A7RLDBYUgms37iSYfNvEkBAIzrAsoRKaSMocIRI1bq58ULVO2NCqMnt2qWOnoA==",
+      "sha512": "XSlFRqbEojrHSEffTWFLw7iPa3ZclvAJ/yjBNoCKr4F/xXvqPu4jcDeSb2loWhLTQkwRJR1AM/U7d0EHU6gxhw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -4118,7 +4061,7 @@
     "System.Security.Cryptography.Primitives/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "YEHmq6x6u2grEuZFAX9au+6uY8SCIkA6lu4wbrt2C71RFQKWEyO5G9+pk1v0QcNPqay/38aSm9v/BoTFNQii1Q==",
+      "sha512": "ztiLIQf2hl0ljLzaUeCx5tk+TU8TrHwrEatuKgSl2KoZXxeOCeXnB+oE07xQO7RnnMlPLtX7/ucHQtteh9du7A==",
       "files": [
         "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -4140,7 +4083,7 @@
     "System.Security.Cryptography.X509Certificates/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "IHh/XFAiku2Xih0WCN4LsZ4QC5bAiq0Qb+SIkiKHBSTHXDtQJNBuMoTZUSr51uIfuw/Fep3sW04rH4cxXmO36w==",
+      "sha512": "yIZEPChGR0OcuBjjDPm+CcwPW5HQgRQ2JQrbdRRWaYKI0p9BfbyUbQOb9te26BnBj4WFgFd5zlSxHlW3oX2BkQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -4286,7 +4229,7 @@
     "System.Text.RegularExpressions/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Iz3942FXA47VxsuJTBq4aA/gevsbdMhyUnQD6Y0aHt57oP6KAwZLaxVtrRzB03yxh6oGBlvQfxBlsXWnLLj4gg==",
+      "sha512": "ZtarWBvDF7R6pRqo1jxo+uV46Rzxht8rRTe+qSHrr6SLLiZRL4RMncU+mDEn81wF+WL+v81ug20lnssHNHlV+Q==",
       "files": [
         "lib/dotnet5.4/System.Text.RegularExpressions.dll",
         "lib/MonoAndroid10/_._",
@@ -4347,7 +4290,7 @@
     "System.Threading/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "AiuvOzOo6CZpIIw3yGJZcs3IhiCZcy0P/ThubazmWExERHJZoOnD/jB+Bn2gxTAD0rc/ytrRdBur9PuX6DvvvA==",
+      "sha512": "vZNXMOIwejg9jS/AkkCs43BIDrzONbT43yhU7X2217Ypi9EZN5X16DwtqBD7eMjDBsA23IRZxuugzUnV8icaxQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -4466,7 +4409,7 @@
     "System.Threading.Thread/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2a5k/EmBXNiIoQZ8hk32KjoCVs1E5OdQtqJCHcW4qThmk+m/siQgB7zYamlRBeQ5zJs7c1l4oN/y5+YRq8oQ2Q==",
+      "sha512": "/yo7KuZ9zLrB3hdWARrvus3YTAdvvuqHWf2oMNpyG1mpoVlmhRwkZ9JqYRC+TL3hSFHa7mvHa8EItA+BBahlsA==",
       "files": [
         "lib/DNXCore50/System.Threading.Thread.dll",
         "lib/MonoAndroid10/_._",
@@ -4498,7 +4441,7 @@
     "System.Threading.ThreadPool/4.0.10-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xDTdxmxDAfIMrbANWXQih80yOTbyXhU5z/2P15n3EuyJOetqKKVWEXouoD8bV25RzJHuB2rHMTZhUmbtLmEpwA==",
+      "sha512": "s7KzGX8skWrj2raEEWt/qbMUPZJuHlwW6XP1fC4yltuX+6FqPA/D5fag8Q0/TsbcCcC8Q50+fULuHjlCNeblow==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",

--- a/src/Serilog.Sinks.Seq/project.json
+++ b/src/Serilog.Sinks.Seq/project.json
@@ -7,9 +7,9 @@
   "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
   "iconUrl": "http://serilog.net/images/serilog-sink-seq-nuget.png",
   "dependencies": {
-    "Serilog": "2.0.0-beta-465",
-    "Serilog.Sinks.PeriodicBatching": "2.0.0-beta-465",
-    "Serilog.Sinks.RollingFile":  "2.0.0-beta-465"
+    "Serilog": "2.0.0-beta-505",
+    "Serilog.Sinks.PeriodicBatching": "2.0.0-beta-505",
+    "Serilog.Sinks.RollingFile":  "2.0.0-beta-505"
   },
   "frameworks": {
     "net45": {

--- a/src/Serilog.Sinks.Seq/project.lock.json
+++ b/src/Serilog.Sinks.Seq/project.lock.json
@@ -3,13 +3,12 @@
   "version": 2,
   "targets": {
     ".NETFramework,Version=v4.5": {
-      "Serilog/2.0.0-beta-465": {
+      "Serilog/2.0.0-beta-505": {
         "type": "package",
         "frameworkAssemblies": [
           "Microsoft.CSharp",
           "mscorlib",
           "System",
-          "System.Configuration",
           "System.Core"
         ],
         "compile": {
@@ -19,10 +18,10 @@
           "lib/net45/Serilog.dll": {}
         }
       },
-      "Serilog.Sinks.File/2.0.0-beta-465": {
+      "Serilog.Sinks.File/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "Microsoft.CSharp",
@@ -31,52 +30,35 @@
           "System.Core"
         ],
         "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
           "lib/net45/Serilog.Sinks.File.dll": {}
         },
         "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
           "lib/net45/Serilog.Sinks.File.dll": {}
         }
       },
-      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-465": {
+      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "Microsoft.CSharp",
           "mscorlib",
           "System",
-          "System.Configuration",
           "System.Core"
         ],
         "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
           "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
         },
         "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
           "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
         }
       },
-      "Serilog.Sinks.RollingFile/2.0.0-beta-465": {
+      "Serilog.Sinks.RollingFile/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.File": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.File": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "Microsoft.CSharp",
@@ -85,21 +67,9 @@
           "System.Core"
         ],
         "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {},
           "lib/net45/Serilog.Sinks.RollingFile.dll": {}
         },
         "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {},
           "lib/net45/Serilog.Sinks.RollingFile.dll": {}
         }
       }
@@ -132,7 +102,7 @@
           "lib/dotnet5.4/Microsoft.CSharp.dll": {}
         }
       },
-      "Serilog/2.0.0-beta-465": {
+      "Serilog/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
           "Microsoft.CSharp": "4.0.1-beta-23516",
@@ -146,6 +116,7 @@
           "System.Linq": "4.0.1-beta-23516",
           "System.Reflection.Extensions": "4.0.1-beta-23516",
           "System.Runtime.Extensions": "4.0.11-beta-23516",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23516",
           "System.Text.RegularExpressions": "4.0.11-beta-23516",
           "System.Threading": "4.0.11-beta-23516",
           "System.Threading.Thread": "4.0.0-beta-23516"
@@ -157,56 +128,46 @@
           "lib/dotnet5.4/Serilog.dll": {}
         }
       },
-      "Serilog.Sinks.File/2.0.0-beta-465": {
+      "Serilog.Sinks.File/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
           "System.IO": "4.0.11-beta-23516",
           "System.IO.FileSystem": "4.0.0",
           "System.IO.FileSystem.Primitives": "4.0.0"
         },
         "compile": {
-          "lib/dotnet5.1/Serilog.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.Console.dll": {},
           "lib/dotnet5.1/Serilog.Sinks.File.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.1/Serilog.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.Console.dll": {},
           "lib/dotnet5.1/Serilog.Sinks.File.dll": {}
         }
       },
-      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-465": {
+      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
           "System.Collections.Concurrent": "4.0.11-beta-23516"
         },
         "compile": {
-          "lib/dotnet5.2/Serilog.Sinks.Observable.dll": {},
           "lib/dotnet5.2/Serilog.Sinks.PeriodicBatching.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.2/Serilog.Sinks.Observable.dll": {},
           "lib/dotnet5.2/Serilog.Sinks.PeriodicBatching.dll": {}
         }
       },
-      "Serilog.Sinks.RollingFile/2.0.0-beta-465": {
+      "Serilog.Sinks.RollingFile/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.File": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.File": "2.0.0-beta-505",
           "System.IO": "4.0.11-beta-23516",
           "System.IO.FileSystem.Primitives": "4.0.1-beta-23516"
         },
         "compile": {
-          "lib/dotnet5.4/Serilog.dll": {},
           "lib/dotnet5.4/Serilog.Sinks.RollingFile.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.4/Serilog.dll": {},
           "lib/dotnet5.4/Serilog.Sinks.RollingFile.dll": {}
         }
       },
@@ -497,6 +458,19 @@
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
         }
       },
+      "System.Runtime.Serialization.Primitives/4.1.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
+        }
+      },
       "System.Text.Encoding/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -553,13 +527,12 @@
       }
     },
     ".NETFramework,Version=v4.5/win7-x86": {
-      "Serilog/2.0.0-beta-465": {
+      "Serilog/2.0.0-beta-505": {
         "type": "package",
         "frameworkAssemblies": [
           "Microsoft.CSharp",
           "mscorlib",
           "System",
-          "System.Configuration",
           "System.Core"
         ],
         "compile": {
@@ -569,10 +542,10 @@
           "lib/net45/Serilog.dll": {}
         }
       },
-      "Serilog.Sinks.File/2.0.0-beta-465": {
+      "Serilog.Sinks.File/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "Microsoft.CSharp",
@@ -581,52 +554,35 @@
           "System.Core"
         ],
         "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
           "lib/net45/Serilog.Sinks.File.dll": {}
         },
         "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
           "lib/net45/Serilog.Sinks.File.dll": {}
         }
       },
-      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-465": {
+      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "Microsoft.CSharp",
           "mscorlib",
           "System",
-          "System.Configuration",
           "System.Core"
         ],
         "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
           "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
         },
         "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
           "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
         }
       },
-      "Serilog.Sinks.RollingFile/2.0.0-beta-465": {
+      "Serilog.Sinks.RollingFile/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.File": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.File": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "Microsoft.CSharp",
@@ -635,33 +591,20 @@
           "System.Core"
         ],
         "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {},
           "lib/net45/Serilog.Sinks.RollingFile.dll": {}
         },
         "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {},
           "lib/net45/Serilog.Sinks.RollingFile.dll": {}
         }
       }
     },
     ".NETFramework,Version=v4.5/win7-x64": {
-      "Serilog/2.0.0-beta-465": {
+      "Serilog/2.0.0-beta-505": {
         "type": "package",
         "frameworkAssemblies": [
           "Microsoft.CSharp",
           "mscorlib",
           "System",
-          "System.Configuration",
           "System.Core"
         ],
         "compile": {
@@ -671,10 +614,10 @@
           "lib/net45/Serilog.dll": {}
         }
       },
-      "Serilog.Sinks.File/2.0.0-beta-465": {
+      "Serilog.Sinks.File/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "Microsoft.CSharp",
@@ -683,52 +626,35 @@
           "System.Core"
         ],
         "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
           "lib/net45/Serilog.Sinks.File.dll": {}
         },
         "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
           "lib/net45/Serilog.Sinks.File.dll": {}
         }
       },
-      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-465": {
+      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "Microsoft.CSharp",
           "mscorlib",
           "System",
-          "System.Configuration",
           "System.Core"
         ],
         "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
           "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
         },
         "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
           "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {}
         }
       },
-      "Serilog.Sinks.RollingFile/2.0.0-beta-465": {
+      "Serilog.Sinks.RollingFile/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.File": "2.0.0-beta-465"
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.File": "2.0.0-beta-505"
         },
         "frameworkAssemblies": [
           "Microsoft.CSharp",
@@ -737,21 +663,9 @@
           "System.Core"
         ],
         "compile": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {},
           "lib/net45/Serilog.Sinks.RollingFile.dll": {}
         },
         "runtime": {
-          "lib/net45/Serilog.dll": {},
-          "lib/net45/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/net45/Serilog.Sinks.Console.dll": {},
-          "lib/net45/Serilog.Sinks.File.dll": {},
-          "lib/net45/Serilog.Sinks.Observable.dll": {},
-          "lib/net45/Serilog.Sinks.PeriodicBatching.dll": {},
           "lib/net45/Serilog.Sinks.RollingFile.dll": {}
         }
       }
@@ -870,7 +784,7 @@
           "ref/dotnet/_._": {}
         }
       },
-      "Serilog/2.0.0-beta-465": {
+      "Serilog/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
           "Microsoft.CSharp": "4.0.1-beta-23516",
@@ -884,6 +798,7 @@
           "System.Linq": "4.0.1-beta-23516",
           "System.Reflection.Extensions": "4.0.1-beta-23516",
           "System.Runtime.Extensions": "4.0.11-beta-23516",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23516",
           "System.Text.RegularExpressions": "4.0.11-beta-23516",
           "System.Threading": "4.0.11-beta-23516",
           "System.Threading.Thread": "4.0.0-beta-23516"
@@ -895,56 +810,46 @@
           "lib/dotnet5.4/Serilog.dll": {}
         }
       },
-      "Serilog.Sinks.File/2.0.0-beta-465": {
+      "Serilog.Sinks.File/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
           "System.IO": "4.0.11-beta-23516",
           "System.IO.FileSystem": "4.0.0",
           "System.IO.FileSystem.Primitives": "4.0.0"
         },
         "compile": {
-          "lib/dotnet5.1/Serilog.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.Console.dll": {},
           "lib/dotnet5.1/Serilog.Sinks.File.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.1/Serilog.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.Console.dll": {},
           "lib/dotnet5.1/Serilog.Sinks.File.dll": {}
         }
       },
-      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-465": {
+      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
           "System.Collections.Concurrent": "4.0.11-beta-23516"
         },
         "compile": {
-          "lib/dotnet5.2/Serilog.Sinks.Observable.dll": {},
           "lib/dotnet5.2/Serilog.Sinks.PeriodicBatching.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.2/Serilog.Sinks.Observable.dll": {},
           "lib/dotnet5.2/Serilog.Sinks.PeriodicBatching.dll": {}
         }
       },
-      "Serilog.Sinks.RollingFile/2.0.0-beta-465": {
+      "Serilog.Sinks.RollingFile/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.File": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.File": "2.0.0-beta-505",
           "System.IO": "4.0.11-beta-23516",
           "System.IO.FileSystem.Primitives": "4.0.1-beta-23516"
         },
         "compile": {
-          "lib/dotnet5.4/Serilog.dll": {},
           "lib/dotnet5.4/Serilog.Sinks.RollingFile.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.4/Serilog.dll": {},
           "lib/dotnet5.4/Serilog.Sinks.RollingFile.dll": {}
         }
       },
@@ -1233,6 +1138,19 @@
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Runtime.Serialization.Primitives/4.1.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
         }
       },
       "System.Text.Encoding/4.0.10": {
@@ -1424,7 +1342,7 @@
           "ref/dotnet/_._": {}
         }
       },
-      "Serilog/2.0.0-beta-465": {
+      "Serilog/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
           "Microsoft.CSharp": "4.0.1-beta-23516",
@@ -1438,6 +1356,7 @@
           "System.Linq": "4.0.1-beta-23516",
           "System.Reflection.Extensions": "4.0.1-beta-23516",
           "System.Runtime.Extensions": "4.0.11-beta-23516",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23516",
           "System.Text.RegularExpressions": "4.0.11-beta-23516",
           "System.Threading": "4.0.11-beta-23516",
           "System.Threading.Thread": "4.0.0-beta-23516"
@@ -1449,56 +1368,46 @@
           "lib/dotnet5.4/Serilog.dll": {}
         }
       },
-      "Serilog.Sinks.File/2.0.0-beta-465": {
+      "Serilog.Sinks.File/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
           "System.IO": "4.0.11-beta-23516",
           "System.IO.FileSystem": "4.0.0",
           "System.IO.FileSystem.Primitives": "4.0.0"
         },
         "compile": {
-          "lib/dotnet5.1/Serilog.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.Console.dll": {},
           "lib/dotnet5.1/Serilog.Sinks.File.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.1/Serilog.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.ColoredConsole.dll": {},
-          "lib/dotnet5.1/Serilog.Sinks.Console.dll": {},
           "lib/dotnet5.1/Serilog.Sinks.File.dll": {}
         }
       },
-      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-465": {
+      "Serilog.Sinks.PeriodicBatching/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
           "System.Collections.Concurrent": "4.0.11-beta-23516"
         },
         "compile": {
-          "lib/dotnet5.2/Serilog.Sinks.Observable.dll": {},
           "lib/dotnet5.2/Serilog.Sinks.PeriodicBatching.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.2/Serilog.Sinks.Observable.dll": {},
           "lib/dotnet5.2/Serilog.Sinks.PeriodicBatching.dll": {}
         }
       },
-      "Serilog.Sinks.RollingFile/2.0.0-beta-465": {
+      "Serilog.Sinks.RollingFile/2.0.0-beta-505": {
         "type": "package",
         "dependencies": {
-          "Serilog": "2.0.0-beta-465",
-          "Serilog.Sinks.File": "2.0.0-beta-465",
+          "Serilog": "2.0.0-beta-505",
+          "Serilog.Sinks.File": "2.0.0-beta-505",
           "System.IO": "4.0.11-beta-23516",
           "System.IO.FileSystem.Primitives": "4.0.1-beta-23516"
         },
         "compile": {
-          "lib/dotnet5.4/Serilog.dll": {},
           "lib/dotnet5.4/Serilog.Sinks.RollingFile.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.4/Serilog.dll": {},
           "lib/dotnet5.4/Serilog.Sinks.RollingFile.dll": {}
         }
       },
@@ -1789,6 +1698,19 @@
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
         }
       },
+      "System.Runtime.Serialization.Primitives/4.1.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
+        }
+      },
       "System.Text.Encoding/4.0.10": {
         "type": "package",
         "dependencies": {
@@ -1869,7 +1791,7 @@
     "Microsoft.CSharp/4.0.1-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fb+HO3nIjHao9lqsVVM0ne3GM/+1EfRQUoM58cxEOt+5biy/8DQ1nxIahZ9VaJKw7Wgb6XhRhsdwg8DkePEOJA==",
+      "sha512": "z/W5YaTGVQ8WX6TQDW8cCBAe2rBhHOD7NZHxLAnBIMoLWMI/upWDi+dxHYMDDWmGOM7a3di6evem2OzOdaB1fQ==",
       "files": [
         "lib/dotnet5.4/Microsoft.CSharp.dll",
         "lib/MonoAndroid10/_._",
@@ -1919,7 +1841,7 @@
     "runtime.win7.System.Console/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "pfQrTtnYcWOtI3RrpqjAzwT3I55ivTVZFpbKYG59dYTTvaLFGbs2njc/mrXHij6GylyJ2YjekS/9r6I8X3LV1A==",
+      "sha512": "TJZhrw44Bf7sYqne+CX5II/PaNf5L7oKVfl0FLkr4pj76KS8hSsJzsKL0IvxC+bi4d51+wTbv91kF1kgPyHMVw==",
       "files": [
         "ref/dotnet/_._",
         "runtime.win7.System.Console.4.0.0-beta-23516.nupkg",
@@ -1932,7 +1854,7 @@
     "runtime.win7.System.Diagnostics.Process/4.1.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "qCCXX+OG6430kLtN/wyjeLTTiJvOIKB2G+qBvhSqVLWe5ZTiEiSnweKUzdi7raXL0te0WfPE5tf8FuKcEKPnIA==",
+      "sha512": "IDp4dljG6NkpMP9UzrtuvLZ0wfeOHphStOsVLmUTj2g3UH28L5Lo9481/fAXVPs2GEVMRwAvSwph90EcNfV/jQ==",
       "files": [
         "ref/dotnet/_._",
         "runtime.win7.System.Diagnostics.Process.4.1.0-beta-23516.nupkg",
@@ -1949,7 +1871,7 @@
     "runtime.win7.System.Diagnostics.TraceSource/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "hpD0T6zOEU/1qUSPitKSgIdsL4tZlZz7CUCu6PP7BYf8CM3vPkSEzN38kX6PnH8F6kvOqxEwzPYhZCK3PJkh/Q==",
+      "sha512": "6YSh7+vRI2ptFNPTWE100MNz0sRAVuBjwU0znK3kzd5GYQgLjvtWn8rT9DvJQA4R6OmC5Q+OgXzb/nibxcbtbA==",
       "files": [
         "ref/dotnet/_._",
         "runtime.win7.System.Diagnostics.TraceSource.4.0.0-beta-23516.nupkg",
@@ -1966,7 +1888,7 @@
     "runtime.win7.System.IO.FileSystem/4.0.1-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "UOHEVg3jQwsvy3b+8zhDk7BQ9GhHY1KcjHSuqArzIl7oemcM/+D7OfS5iOA96ydjEv9FmIKV3knkXMge+cUD0Q==",
+      "sha512": "PwsqcwAui7Ld6Ad32RjoHF3wBSEkEzvv5ka605IsaWxHSCfmmwevJnIbNgwJgBTao/uR+wSO9yoyvfrB109BfQ==",
       "files": [
         "ref/dotnet/_._",
         "runtime.win7.System.IO.FileSystem.4.0.1-beta-23516.nupkg",
@@ -1996,7 +1918,7 @@
     "runtime.win7.System.Runtime.Extensions/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Jm+LAzN7CZl1BZSxz4TsMBNy1rHNqyY/1+jxZf3BpF7vkPlWRXa/vSfY0lZJZdy4Doxa893bmcCf9pZNsJU16Q==",
+      "sha512": "V4HbLYv2m4LaL+Kl+x6wz8Xl9TyrHBpA/lYq+w6J35mYY9ACCVV+YkHRJdNuRd3Qe3DEz9X8D1S8uWnKMyHvvg==",
       "files": [
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/netcore50/System.Runtime.Extensions.dll",
@@ -2010,7 +1932,7 @@
     "runtime.win7.System.Threading/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "paSNXQ5Y6Exu3OpekooyMJFQ8mitn69fGO5Br3XLIfQ1KiMYVmRf+o6dMprC0SpPROVCiCxdUaJx5XkDEVL3uA==",
+      "sha512": "kKQ9uUB1g3S9eyK5njdwh5LO0HxJ9CN6cF9dXtp7uzdZvh2UoTgAZ0Jf+/TvzWcUsfcKIPQUGPPLOBLaQpXASg==",
       "files": [
         "ref/dotnet/_._",
         "runtime.win7.System.Threading.4.0.11-beta-23516.nupkg",
@@ -2021,97 +1943,57 @@
         "runtimes/win8-aot/lib/netcore50/System.Threading.dll"
       ]
     },
-    "Serilog/2.0.0-beta-465": {
+    "Serilog/2.0.0-beta-505": {
       "type": "package",
-      "sha512": "WCWljYsF2u2gzcKAAieKisqI4GXfd1Y97jfOa+yfqfLhur0VOt/20SwEQprOBfpSdlKbDbefSg9PjaLB0HzR6A==",
+      "sha512": "Pp8dfTjdUfYkwRGi3Ukxxxx+gJxnVeXO1TA6U3uISCcymKZLCkV1pHHwbZA8XjroTOV4a4Jzim9NK7zyab/lZQ==",
       "files": [
         "lib/dotnet5.1/Serilog.dll",
         "lib/dotnet5.1/Serilog.xml",
         "lib/dotnet5.4/Serilog.dll",
         "lib/dotnet5.4/Serilog.xml",
-        "lib/net40/Serilog.dll",
-        "lib/net40/Serilog.xml",
         "lib/net45/Serilog.dll",
         "lib/net45/Serilog.xml",
-        "Serilog.2.0.0-beta-465.nupkg",
-        "Serilog.2.0.0-beta-465.nupkg.sha512",
+        "Serilog.2.0.0-beta-505.nupkg",
+        "Serilog.2.0.0-beta-505.nupkg.sha512",
         "Serilog.nuspec"
       ]
     },
-    "Serilog.Sinks.File/2.0.0-beta-465": {
+    "Serilog.Sinks.File/2.0.0-beta-505": {
       "type": "package",
-      "sha512": "FVLlr0971K7AEiDIMEMNxEsfqIHxvOakD4PjlpNKl0IhGP+ZX5DX9pCFENta7jTe7KU4vz3MVWvo7GDmdHamaQ==",
+      "sha512": "COA3V43z40MdSP3c0pXZX6SadoxgH6QckcNL332dgcnisCgw6kEDVzS7p89P+/+3keyYye6vDHkSTE09Khv7kQ==",
       "files": [
-        "lib/dotnet5.1/Serilog.dll",
-        "lib/dotnet5.1/Serilog.Sinks.ColoredConsole.dll",
-        "lib/dotnet5.1/Serilog.Sinks.ColoredConsole.xml",
-        "lib/dotnet5.1/Serilog.Sinks.Console.dll",
-        "lib/dotnet5.1/Serilog.Sinks.Console.xml",
         "lib/dotnet5.1/Serilog.Sinks.File.dll",
         "lib/dotnet5.1/Serilog.Sinks.File.xml",
-        "lib/dotnet5.1/Serilog.xml",
-        "lib/net45/Serilog.dll",
-        "lib/net45/Serilog.Sinks.ColoredConsole.dll",
-        "lib/net45/Serilog.Sinks.ColoredConsole.xml",
-        "lib/net45/Serilog.Sinks.Console.dll",
-        "lib/net45/Serilog.Sinks.Console.xml",
         "lib/net45/Serilog.Sinks.File.dll",
         "lib/net45/Serilog.Sinks.File.xml",
-        "lib/net45/Serilog.xml",
-        "Serilog.Sinks.File.2.0.0-beta-465.nupkg",
-        "Serilog.Sinks.File.2.0.0-beta-465.nupkg.sha512",
+        "Serilog.Sinks.File.2.0.0-beta-505.nupkg",
+        "Serilog.Sinks.File.2.0.0-beta-505.nupkg.sha512",
         "Serilog.Sinks.File.nuspec"
       ]
     },
-    "Serilog.Sinks.PeriodicBatching/2.0.0-beta-465": {
+    "Serilog.Sinks.PeriodicBatching/2.0.0-beta-505": {
       "type": "package",
-      "sha512": "KPtLMJfGhsGNkaluN43CRisEqIoOjhpNZdr4NmbOLvPhKauD7deO8n9gwiC7Bmh5ZV8pz2ilaerJ1QY/r+ggDg==",
+      "sha512": "5r8Lh4UW+YNMbIzown4moCLEAPEB/Wo7ug0I5Fd8Tjc6G4398NJqzLJgK2IIShcYsqAmIZiM+pl+ll6gdP1piQ==",
       "files": [
-        "lib/dotnet5.2/Serilog.Sinks.Observable.dll",
-        "lib/dotnet5.2/Serilog.Sinks.Observable.xml",
         "lib/dotnet5.2/Serilog.Sinks.PeriodicBatching.dll",
         "lib/dotnet5.2/Serilog.Sinks.PeriodicBatching.xml",
-        "lib/net45/Serilog.dll",
-        "lib/net45/Serilog.Sinks.ColoredConsole.dll",
-        "lib/net45/Serilog.Sinks.ColoredConsole.xml",
-        "lib/net45/Serilog.Sinks.Console.dll",
-        "lib/net45/Serilog.Sinks.Console.xml",
-        "lib/net45/Serilog.Sinks.File.dll",
-        "lib/net45/Serilog.Sinks.File.xml",
-        "lib/net45/Serilog.Sinks.Observable.dll",
-        "lib/net45/Serilog.Sinks.Observable.xml",
         "lib/net45/Serilog.Sinks.PeriodicBatching.dll",
         "lib/net45/Serilog.Sinks.PeriodicBatching.xml",
-        "lib/net45/Serilog.xml",
-        "Serilog.Sinks.PeriodicBatching.2.0.0-beta-465.nupkg",
-        "Serilog.Sinks.PeriodicBatching.2.0.0-beta-465.nupkg.sha512",
+        "Serilog.Sinks.PeriodicBatching.2.0.0-beta-505.nupkg",
+        "Serilog.Sinks.PeriodicBatching.2.0.0-beta-505.nupkg.sha512",
         "Serilog.Sinks.PeriodicBatching.nuspec"
       ]
     },
-    "Serilog.Sinks.RollingFile/2.0.0-beta-465": {
+    "Serilog.Sinks.RollingFile/2.0.0-beta-505": {
       "type": "package",
-      "sha512": "CLY7hvQCnCYZ9kCFrsgg9VWoMwM3MKv8M78PPbRNxl/uT/BTzH3uQNfPkQnO3SizbvWKrDquubxoWqwS/L/0Hw==",
+      "sha512": "1mSt+NBL2a9xFcJ36atukRLzqHSXtiaREJM8sgF5/0Rc2+HSDWimpLmmrV2qijBe5jPVBHB1ojxQGLbArPeexQ==",
       "files": [
-        "lib/dotnet5.4/Serilog.dll",
         "lib/dotnet5.4/Serilog.Sinks.RollingFile.dll",
         "lib/dotnet5.4/Serilog.Sinks.RollingFile.xml",
-        "lib/dotnet5.4/Serilog.xml",
-        "lib/net45/Serilog.dll",
-        "lib/net45/Serilog.Sinks.ColoredConsole.dll",
-        "lib/net45/Serilog.Sinks.ColoredConsole.xml",
-        "lib/net45/Serilog.Sinks.Console.dll",
-        "lib/net45/Serilog.Sinks.Console.xml",
-        "lib/net45/Serilog.Sinks.File.dll",
-        "lib/net45/Serilog.Sinks.File.xml",
-        "lib/net45/Serilog.Sinks.Observable.dll",
-        "lib/net45/Serilog.Sinks.Observable.xml",
-        "lib/net45/Serilog.Sinks.PeriodicBatching.dll",
-        "lib/net45/Serilog.Sinks.PeriodicBatching.xml",
         "lib/net45/Serilog.Sinks.RollingFile.dll",
         "lib/net45/Serilog.Sinks.RollingFile.xml",
-        "lib/net45/Serilog.xml",
-        "Serilog.Sinks.RollingFile.2.0.0-beta-465.nupkg",
-        "Serilog.Sinks.RollingFile.2.0.0-beta-465.nupkg.sha512",
+        "Serilog.Sinks.RollingFile.2.0.0-beta-505.nupkg",
+        "Serilog.Sinks.RollingFile.2.0.0-beta-505.nupkg.sha512",
         "Serilog.Sinks.RollingFile.nuspec"
       ]
     },
@@ -2152,7 +2034,7 @@
     "System.Collections.Concurrent/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "e4FscEk9ugPXPKEIQFYBS/i+0KAkKf/IEe26fiOnqk8JVZQuCLO3gJmJ+IiVD1TxJjvVmh+tayQuo2svVzZV7g==",
+      "sha512": "K+n6bC3jL5nRzwm8IM5WHxPScCnrVoPCJjpkBEmoBYY8/3j4RJdqIng/NYcpGcjvP/GIF6tAwZlh54ao2pWOvQ==",
       "files": [
         "lib/dotnet5.4/System.Collections.Concurrent.dll",
         "lib/MonoAndroid10/_._",
@@ -2211,7 +2093,7 @@
     "System.Console/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "0YTzoNamTU+6qfZEYtMuGjtkJHB1MEDyFsZ5L/x97GkZO3Bw91uwdPh0DkFwQ6E8KaQTgZAecSXoboUHAcdSLA==",
+      "sha512": "tzF4Dbbv+5bcbQ7GHuuKafkaDZThiUiwxqCc1ngewnMWZ5YmIgjQZjs+E1DNhoMVAvkH0tSmLJvsDlx9dFg+Aw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2322,7 +2204,7 @@
     "System.Diagnostics.TraceSource/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OIWB5pvMqOdCraAtiJBhRahrsnP2sNaXbCZNdAadzwiPLzRI7EvLTc7/NlkFDxm3I6YKVGxnJ5aO+YJ/XPC8yw==",
+      "sha512": "gvJNxObthiaV07AKZYjQV69xRBKRR7gTpEVe4qXF4Mta/2zD7sI+Zm//rRCQenLYBuL8nBxVzomtYJ4eT7w8QQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2436,7 +2318,7 @@
     "System.Globalization/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "htoF4cS3WhCkU3HloMj3mz+h2FHnF8Hz0po/26otT5e46LlJ8p7LpFpxckxVviyYg9Fab9gr8aIB0ZDN9Cjpig==",
+      "sha512": "jctanC1VveBFsgOysiqFN/HH0qX+EvLNelcBU6Fb4w7m3BBu827k8RCNiwW+uAC5f5XZBTRpsXZk4cI15RCdYQ==",
       "files": [
         "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
@@ -2498,7 +2380,7 @@
     "System.IO/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "dR1DaWrF0zsV2z/GVs8xVvMds6xu0ykuwv+VPou8wbpJ1XxGBK9g6v5F84DWL8Q1qi+6Kyb56wbZYdYQO8OMew==",
+      "sha512": "6nJmAk4vYjN+5/haenkKk/BDGCOKw5pk5EjXAOvBnUM5PFIfO8JwUxGbcveOD4vV5Vb6TAxrmRmts/7F+BEuEw==",
       "files": [
         "lib/DNXCore50/System.IO.dll",
         "lib/MonoAndroid10/_._",
@@ -2560,7 +2442,7 @@
     "System.IO.FileSystem/4.0.1-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "KOYNQ6FeLQh0HdHVlp6IRjRGPCjyFvZRKfhYSDFi7DR0EHY3cC2rvfVj5HWJEW5KlSaa01Ct25m06yVnqSxwOQ==",
+      "sha512": "xggWMgLzKnBisYTx5HW3og8qRR7TjmorQAdsAQOaMcY4I9CQA6JUxw0r2AvCC1+ToXh0CuO7J6dymX33pkmwbA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2624,7 +2506,7 @@
     "System.Linq/4.0.1-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "uNxm2RB+kMeiKnY26iPvOtJLzTzNaAF4A2qqyzev6j8x8w2Dr+gg7LF7BHCwC55N7OirhHrAWUb3C0n4oi9qYw==",
+      "sha512": "AJaoyeAHLpurbTWnmvOhK/QC2sswKJrIA5RlPea+UdfXpHOw3srPNEPpseZDMV/EviVqAwUfFNkc5QxpGZtsLA==",
       "files": [
         "lib/dotnet5.4/System.Linq.dll",
         "lib/net45/_._",
@@ -2864,7 +2746,7 @@
     "System.Reflection.Extensions/4.0.1-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "CiaYbkU2dzOSTSB7X/xLvlae3rop8xz62XjflUSnyCaRPB5XaQR4JasHW07/lRKJowt67Km7K1LMpYEmoRku8w==",
+      "sha512": "Ph0ELqqqz218bGEtnfQ1xegANVQ3v0S/hU12AHpb4HEw8SESssbNCKWEVjeI3y2xDYaVx1aVjM4hZ1QXa4IonQ==",
       "files": [
         "lib/DNXCore50/System.Reflection.Extensions.dll",
         "lib/net45/_._",
@@ -3043,7 +2925,7 @@
     "System.Runtime.Extensions/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "HX4wNPrcCV9D+jpbsJCRPuVJbcDM+JobSotQWKq40lCq0WJbJi+0lNQ/T1zHEdWcf4W2PmtMkug1rW7yKW9PiQ==",
+      "sha512": "mpKQVIySlFSvgQkeb9qvXxHOY3jV7H9x5DmPSeNac0APFOG9ROufrMozY3VP/GxBWu4AVS/HDG1lUxg/riE4ew==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3168,6 +3050,67 @@
         "System.Runtime.InteropServices.nuspec"
       ]
     },
+    "System.Runtime.Serialization.Primitives/4.1.0-beta-23516": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "Dsl95PE2vyGIy9voclfTVKSqYD8O4PjsMS+TV0bM3N1xNraS2BBaChGk1stGmf04cn2/xA3cZyh80bkZL+v1/Q==",
+      "files": [
+        "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/System.Runtime.Serialization.Primitives.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet5.1/de/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/es/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/fr/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/it/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/ja/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/ko/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/ru/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/System.Runtime.Serialization.Primitives.dll",
+        "ref/dotnet5.1/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/zh-hans/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.1/zh-hant/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/de/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/es/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/fr/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/it/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/ja/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/ko/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/ru/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/System.Runtime.Serialization.Primitives.dll",
+        "ref/dotnet5.4/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/zh-hans/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet5.4/zh-hant/System.Runtime.Serialization.Primitives.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/es/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/fr/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/it/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/ja/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/ko/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/ru/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/System.Runtime.Serialization.Primitives.dll",
+        "ref/netcore50/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/zh-hans/System.Runtime.Serialization.Primitives.xml",
+        "ref/netcore50/zh-hant/System.Runtime.Serialization.Primitives.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Runtime.Serialization.Primitives.4.1.0-beta-23516.nupkg",
+        "System.Runtime.Serialization.Primitives.4.1.0-beta-23516.nupkg.sha512",
+        "System.Runtime.Serialization.Primitives.nuspec"
+      ]
+    },
     "System.Text.Encoding/4.0.0": {
       "type": "package",
       "sha512": "AMxFNOXpA6Ab8swULbXuJmoT2K5w6TnV3ObF5wsmEcIHQUJghoZtDVfVHb08O2wW15mOSI1i9Wg0Dx0pY13o8g==",
@@ -3285,7 +3228,7 @@
     "System.Text.RegularExpressions/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Iz3942FXA47VxsuJTBq4aA/gevsbdMhyUnQD6Y0aHt57oP6KAwZLaxVtrRzB03yxh6oGBlvQfxBlsXWnLLj4gg==",
+      "sha512": "ZtarWBvDF7R6pRqo1jxo+uV46Rzxht8rRTe+qSHrr6SLLiZRL4RMncU+mDEn81wF+WL+v81ug20lnssHNHlV+Q==",
       "files": [
         "lib/dotnet5.4/System.Text.RegularExpressions.dll",
         "lib/MonoAndroid10/_._",
@@ -3346,7 +3289,7 @@
     "System.Threading/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "AiuvOzOo6CZpIIw3yGJZcs3IhiCZcy0P/ThubazmWExERHJZoOnD/jB+Bn2gxTAD0rc/ytrRdBur9PuX6DvvvA==",
+      "sha512": "vZNXMOIwejg9jS/AkkCs43BIDrzONbT43yhU7X2217Ypi9EZN5X16DwtqBD7eMjDBsA23IRZxuugzUnV8icaxQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3465,7 +3408,7 @@
     "System.Threading.Thread/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2a5k/EmBXNiIoQZ8hk32KjoCVs1E5OdQtqJCHcW4qThmk+m/siQgB7zYamlRBeQ5zJs7c1l4oN/y5+YRq8oQ2Q==",
+      "sha512": "/yo7KuZ9zLrB3hdWARrvus3YTAdvvuqHWf2oMNpyG1mpoVlmhRwkZ9JqYRC+TL3hSFHa7mvHa8EItA+BBahlsA==",
       "files": [
         "lib/DNXCore50/System.Threading.Thread.dll",
         "lib/MonoAndroid10/_._",
@@ -3497,9 +3440,9 @@
   },
   "projectFileDependencyGroups": {
     "": [
-      "Serilog >= 2.0.0-beta-465",
-      "Serilog.Sinks.PeriodicBatching >= 2.0.0-beta-465",
-      "Serilog.Sinks.RollingFile >= 2.0.0-beta-465"
+      "Serilog >= 2.0.0-beta-505",
+      "Serilog.Sinks.PeriodicBatching >= 2.0.0-beta-505",
+      "Serilog.Sinks.RollingFile >= 2.0.0-beta-505"
     ],
     ".NETFramework,Version=v4.5": [
       "fx/System.Net.Http "


### PR DESCRIPTION
I ran into some trouble with Serilog-2.0.0-beta-505 and dependencies when using older builds, and once I sorted those out, I ended up with a runtime error attempting to open RollingFile. I think moving the dependency up to 505 is a first step to fixing that, although there were no code changes necessary. Did RollingFile change to take some optional parameters that were once required?