### PR TITLE
Drop events that cannot be rendered successfully into JSON

### DIFF
--- a/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
@@ -47,7 +47,7 @@ namespace Serilog
         /// <param name="controlLevelSwitch">If provided, the switch will be updated based on the Seq server's level setting
         /// for the corresponding API key. Passing the same key to MinimumLevel.ControlledBy() will make the whole pipeline
         /// dynamically controlled. Do not specify <paramref name="restrictedToMinimumLevel"/> with this setting.</param>
-        /// <param name="messageHandler">Used to construct the HttpClient that will be used to send the log meesages to Seq.</param>
+        /// <param name="messageHandler">Used to construct the HttpClient that will send the log meesages to Seq.</param>
         /// <param name="retainedInvalidPayloadsLimitBytes">A soft limit for the number of bytes to use for storing failed requests.  
         /// The limit is soft in that it can be exceeded by any single error payload, but in that case only that single error
         /// payload will be retained.</param>

--- a/test/Serilog.Sinks.Seq.Tests/SeqSinkTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/SeqSinkTests.cs
@@ -1,0 +1,24 @@
+﻿using Serilog.Sinks.Seq.Tests.Support;
+using Xunit;
+
+namespace Serilog.Sinks.Seq.Tests
+{
+    public class SeqSinkTests
+    {
+        [Fact]
+        public void EventsAreFormattedIntoJsonPayloads()
+        {
+            var evt = Some.LogEvent("Hello, {Name}!", "Alice");
+            var json = SeqSink.FormatPayload(new[] {evt}, null);
+            Assert.Contains("Name\":\"Alice", json);
+        }
+
+        [Fact]
+        public void EventsAreDroppedWhenJsonRenderingFails()
+        {
+            var evt = Some.LogEvent(new NastyException(), "Hello, {Name}!", "Alice");
+            var json = SeqSink.FormatPayload(new[] { evt }, null);
+            Assert.Contains("[]", json);
+        }
+    }
+}

--- a/test/Serilog.Sinks.Seq.Tests/Support/NastyException.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Support/NastyException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Serilog.Sinks.Seq.Tests.Support
+{
+    public class NastyException : Exception
+    {
+        public override string ToString()
+        {
+            throw new InvalidOperationException("Can't ToString() a NastyException!");
+        }
+    }
+}

--- a/test/Serilog.Sinks.Seq.Tests/Support/Some.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Support/Some.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using Serilog.Events;
+using Xunit.Sdk;
+
+namespace Serilog.Sinks.Seq.Tests.Support
+{
+    static class Some
+    {
+        public static LogEvent LogEvent(string messageTemplate, params object[] propertyValues)
+        {
+            return LogEvent(null, messageTemplate, propertyValues);
+        }
+
+        public static LogEvent LogEvent(Exception exception, string messageTemplate, params object[] propertyValues)
+        {
+            var log = new LoggerConfiguration().CreateLogger();
+            MessageTemplate template;
+            IEnumerable<LogEventProperty> properties;
+#pragma warning disable Serilog004 // Constant MessageTemplate verifier
+            if (!log.BindMessageTemplate(messageTemplate, propertyValues, out template, out properties))
+#pragma warning restore Serilog004 // Constant MessageTemplate verifier
+            {
+                throw new XunitException("Template could not be bound.");
+            }
+            return new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, exception, template, properties);
+        }
+    }
+}


### PR DESCRIPTION
(Non-durable mode only). Fixes https://github.com/serilog/serilog/issues/793.