### PR TITLE
Adds auditing support (Serilog 2.2)

### DIFF
--- a/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
@@ -27,7 +27,7 @@ namespace Serilog
     public static class SeqLoggerConfigurationExtensions
     {
         /// <summary>
-        /// Adds a sink that writes log events to a http://getseq.net Seq event server.
+        /// Adds a sink that writes log events to a <a href="https://getseq.net">Seq</a> server.
         /// </summary>
         /// <param name="loggerSinkConfiguration">The logger configuration.</param>
         /// <param name="serverUrl">The base URL of the Seq server that log events will be written to.</param>
@@ -65,7 +65,7 @@ namespace Serilog
             string apiKey = null,
             string bufferBaseFilename = null,
             long? bufferFileSizeLimitBytes = null,
-            long? eventBodyLimitBytes = 256 * 1024,
+            long? eventBodyLimitBytes = 256*1024,
             LoggingLevelSwitch controlLevelSwitch = null,
             HttpMessageHandler messageHandler = null,
             long? retainedInvalidPayloadsLimitBytes = null,
@@ -73,7 +73,8 @@ namespace Serilog
         {
             if (loggerSinkConfiguration == null) throw new ArgumentNullException(nameof(loggerSinkConfiguration));
             if (serverUrl == null) throw new ArgumentNullException(nameof(serverUrl));
-            if (bufferFileSizeLimitBytes.HasValue && bufferFileSizeLimitBytes < 0) throw new ArgumentException("Negative value provided; file size limit must be non-negative");
+            if (bufferFileSizeLimitBytes.HasValue && bufferFileSizeLimitBytes < 0)
+                throw new ArgumentException("Negative value provided; file size limit must be non-negative");
 
             var defaultedPeriod = period ?? SeqSink.DefaultPeriod;
 
@@ -82,10 +83,10 @@ namespace Serilog
             if (bufferBaseFilename == null)
             {
                 sink = new SeqSink(
-                    serverUrl, 
-                    apiKey, 
-                    batchPostingLimit, 
-                    defaultedPeriod, 
+                    serverUrl,
+                    apiKey,
+                    batchPostingLimit,
+                    defaultedPeriod,
                     eventBodyLimitBytes,
                     controlLevelSwitch,
                     messageHandler,
@@ -112,6 +113,37 @@ namespace Serilog
             }
 
             return loggerSinkConfiguration.Sink(sink, restrictedToMinimumLevel);
+        }
+
+        /// <summary>
+        /// Adds a sink that writes audit log events to a <a href="https://getseq.net">Seq</a> server. Auditing writes are
+        /// synchronous and non-batched; any failures will propagate to the caller immediately as exceptions.
+        /// </summary>
+        /// <param name="loggerAuditSinkConfiguration">The logger configuration.</param>
+        /// <param name="serverUrl">The base URL of the Seq server that log events will be written to.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required 
+        /// in order to write an event to the sink.</param>
+        /// <param name="apiKey">A Seq <i>API key</i> that authenticates the client to the Seq server.</param>
+        /// <param name="messageHandler">Used to construct the HttpClient that will send the log meesages to Seq.</param>
+        /// <param name="compact">Use the compact log event format defined by
+        /// <a href="https://github.com/serilog/serilog-formatting-compact">Serilog.Formatting.Compact</a>. Has no effect on
+        /// durable log shipping. Requires Seq 3.3+.</param>
+        /// <returns>Logger configuration, allowing configuration to continue.</returns>
+        /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+        public static LoggerConfiguration Seq(
+            this LoggerAuditSinkConfiguration loggerAuditSinkConfiguration,
+            string serverUrl,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            string apiKey = null,
+            HttpMessageHandler messageHandler = null,
+            bool compact = false)
+        {
+            if (loggerAuditSinkConfiguration == null) throw new ArgumentNullException(nameof(loggerAuditSinkConfiguration));
+            if (serverUrl == null) throw new ArgumentNullException(nameof(serverUrl));
+
+            return loggerAuditSinkConfiguration.Sink(
+                new SeqAuditSink(serverUrl, apiKey, messageHandler, compact),
+                restrictedToMinimumLevel);
         }
     }
 }

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/HttpLogShipper.cs
@@ -74,15 +74,10 @@ namespace Serilog.Sinks.Seq
             _levelControlSwitch = levelControlSwitch;
             _connectionSchedule = new ExponentialBackoffConnectionSchedule(period);
             _retainedInvalidPayloadsLimitBytes = retainedInvalidPayloadsLimitBytes;
-
-            var baseUri = serverUrl;
-            if (!baseUri.EndsWith("/"))
-                baseUri += "/";
-
             _httpClient = messageHandler != null ?
                 new HttpClient(messageHandler) :
                 new HttpClient();
-            _httpClient.BaseAddress = new Uri(baseUri);
+            _httpClient.BaseAddress = new Uri(SeqApi.NormalizeServerBaseAddress(serverUrl));
 
             _bookmarkFilename = Path.GetFullPath(bufferBaseFilename + ".bookmark");
             _logFolder = Path.GetDirectoryName(_bookmarkFilename);

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/SeqApi.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/SeqApi.cs
@@ -55,5 +55,13 @@ namespace Serilog.Sinks.Seq
 
             return minimumLevel;
         }
+
+        public static string NormalizeServerBaseAddress(string serverUrl)
+        {
+            var baseUri = serverUrl;
+            if (!baseUri.EndsWith("/"))
+                baseUri += "/";
+            return baseUri;
+        }
     }
 }

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/SeqAuditSink.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/SeqAuditSink.cs
@@ -1,0 +1,101 @@
+﻿// Serilog.Sinks.Seq Copyright 2016 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Serilog.Core;
+using Serilog.Debugging;
+using Serilog.Events;
+using Serilog.Formatting.Compact;
+using Serilog.Formatting.Json;
+
+namespace Serilog.Sinks.Seq
+{
+    sealed class SeqAuditSink : ILogEventSink, IDisposable
+    {
+        readonly string _apiKey;
+        readonly HttpClient _httpClient;
+        readonly bool _useCompactFormat;
+
+        static readonly JsonValueFormatter JsonValueFormatter = new JsonValueFormatter();
+
+        public SeqAuditSink(
+            string serverUrl,
+            string apiKey,
+            HttpMessageHandler messageHandler,
+            bool useCompactFormat)
+        {
+            if (serverUrl == null) throw new ArgumentNullException(nameof(serverUrl));
+            _apiKey = apiKey;
+            _useCompactFormat = useCompactFormat;
+            _httpClient = messageHandler != null ? new HttpClient(messageHandler) : new HttpClient();
+            _httpClient.BaseAddress = new Uri(SeqApi.NormalizeServerBaseAddress(serverUrl));
+        }
+
+        public void Dispose()
+        {
+            _httpClient.Dispose();
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            EmitAsync(logEvent).Wait();
+        }
+
+        async Task EmitAsync(LogEvent logEvent)
+        {
+            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+
+            string payload, payloadContentType;
+            if (_useCompactFormat)
+            {
+                payloadContentType = SeqApi.CompactLogEventFormatMimeType;
+                payload = FormatCompactPayload(logEvent);
+            }
+            else
+            {
+                payloadContentType = SeqApi.RawEventFormatMimeType;
+                payload = FormatRawPayload(logEvent);
+            }
+
+            var content = new StringContent(payload, Encoding.UTF8, payloadContentType);
+            if (!string.IsNullOrWhiteSpace(_apiKey))
+                content.Headers.Add(SeqApi.ApiKeyHeaderName, _apiKey);
+    
+            var result = await _httpClient.PostAsync(SeqApi.BulkUploadResource, content).ConfigureAwait(false);
+            if (!result.IsSuccessStatusCode)
+                throw new LoggingFailedException($"Received failed result {result.StatusCode} when posting events to Seq");
+        }
+
+        internal static string FormatCompactPayload(LogEvent logEvent)
+        {
+            var payload = new StringWriter();
+            CompactJsonFormatter.FormatEvent(logEvent, payload, JsonValueFormatter);
+            payload.WriteLine();
+            return payload.ToString();
+        }
+
+        internal static string FormatRawPayload(LogEvent logEvent)
+        {
+            var payload = new StringWriter();
+            payload.Write("{\"Events\":[");
+            RawJsonFormatter.FormatContent(logEvent, payload);
+            payload.Write("]}");
+            return payload.ToString();
+        }
+    }
+}

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/SeqSink.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/SeqSink.cs
@@ -62,13 +62,8 @@ namespace Serilog.Sinks.Seq
             _eventBodyLimitBytes = eventBodyLimitBytes;
             _levelControlSwitch = levelControlSwitch;
             _useCompactFormat = useCompactFormat;
-
-            var baseUri = serverUrl;
-            if (!baseUri.EndsWith("/"))
-                baseUri += "/";
-
             _httpClient = messageHandler != null ? new HttpClient(messageHandler) : new HttpClient();
-            _httpClient.BaseAddress = new Uri(baseUri);
+            _httpClient.BaseAddress = new Uri(SeqApi.NormalizeServerBaseAddress(serverUrl));
         }
 
         protected override void Dispose(bool disposing)

--- a/src/Serilog.Sinks.Seq/project.json
+++ b/src/Serilog.Sinks.Seq/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "3.0.0-*",
   "description": "Serilog sink that writes to the Seq event server over HTTP/S.",
   "authors": [ "Serilog Contributors" ],
@@ -9,7 +9,7 @@
     "iconUrl": "http://serilog.net/images/serilog-sink-seq-nuget.png"
   },
   "dependencies": {
-    "Serilog": "2.0.0",
+    "Serilog": "2.2.0-dev-00688",
     "Serilog.Sinks.PeriodicBatching": "2.0.0",
     "Serilog.Formatting.Compact": "1.0.0"
   },

--- a/test/Serilog.Sinks.Seq.Tests/SeqAuditSinkTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/SeqAuditSinkTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Net.Http;
+using Serilog.Debugging;
+using Xunit;
+
+namespace Serilog.Sinks.Seq.Tests
+{
+    public class SeqAuditSinkTests
+    {
+        [Fact]
+        public void EarlyCommunicationErrorsPropagateToCallerWhenAuditing()
+        {
+            using (var logger = new LoggerConfiguration()
+                .AuditTo.Seq("https://example.tld")
+                .CreateLogger())
+            {
+                var ex = Assert.Throws<AggregateException>(() => logger.Information("This is an audit event"));
+                var baseException = ex.GetBaseException();
+                Assert.IsType<HttpRequestException>(baseException);
+            }
+        }
+
+        [Fact]
+        public void RemoteCommunicationErrorsPropagateToCallerWhenAuditing()
+        {
+            using (var logger = new LoggerConfiguration()
+                .AuditTo.Seq("https://serilog.net/test/404")
+                .CreateLogger())
+            {
+                var ex = Assert.Throws<AggregateException>(() => logger.Information("This is an audit event"));
+                var baseException = ex.GetBaseException();
+                Assert.IsType<LoggingFailedException>(baseException);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds:

```csharp
Log.Logger = new LoggerConfiguration()
    .AuditTo.Seq("https://my-seq/prd")
    .CreateLogger();
```

Events logged through the auditing code path are sent synchronously to Seq. Any formatting or communication errors are propagated to the caller.

The tests include an early communication failure (invalid TLD) and remote one (try logging to a random URL at https://serilog.net :-) )