### PR TITLE
Fixes #28 - force BOM when writing durable buffer files

### DIFF
--- a/src/Serilog.Sinks.Seq/Sinks/Seq/DurableSeqSink.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/DurableSeqSink.cs
@@ -19,6 +19,7 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Sinks.RollingFile;
 using System.Net.Http;
+using System.Text;
 
 namespace Serilog.Sinks.Seq
 {
@@ -57,7 +58,8 @@ namespace Serilog.Sinks.Seq
                 bufferBaseFilename + "-{Date}.json",
                 new RawJsonFormatter(),
                 bufferFileSizeLimitBytes,
-                null);
+                null,
+                encoding: Encoding.UTF8);
         }
 
         public void Dispose()


### PR DESCRIPTION
https://github.com/serilog/serilog-sinks-file/pull/10 causes the default file encoding to no longer carry the Unicode BOM, but the file offset calculations in the durable sink already account for it.

By forcing the BOM we'll remain compatible with existing files that use offsets expecting the BOM to be present.

Fixes #28.