### PR TITLE
Update Serilog.Sinks.PeriodicBatching, support queueSizeLimit

### DIFF
--- a/src/Serilog.Sinks.Seq/Sinks/Seq/SeqSink.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/SeqSink.cs
@@ -45,6 +45,7 @@ namespace Serilog.Sinks.Seq
 
         public const int DefaultBatchPostingLimit = 1000;
         public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(2);
+        public const int DefaultQueueSizeLimit = 100000;
 
         public SeqSink(
             string serverUrl,
@@ -54,8 +55,9 @@ namespace Serilog.Sinks.Seq
             long? eventBodyLimitBytes,
             LoggingLevelSwitch levelControlSwitch,
             HttpMessageHandler messageHandler,
-            bool useCompactFormat)
-            : base(batchPostingLimit, period)
+            bool useCompactFormat,
+            int queueSizeLimit)
+            : base(batchPostingLimit, period, queueSizeLimit)
         {
             if (serverUrl == null) throw new ArgumentNullException(nameof(serverUrl));
             _apiKey = apiKey;

--- a/src/Serilog.Sinks.Seq/project.json
+++ b/src/Serilog.Sinks.Seq/project.json
@@ -10,11 +10,13 @@
   },
   "dependencies": {
     "Serilog": "2.2.0",
-    "Serilog.Sinks.PeriodicBatching": "2.0.0",
+    "Serilog.Sinks.PeriodicBatching": "2.1.0",
     "Serilog.Formatting.Compact": "1.0.0"
   },
   "buildOptions": {
-    "keyFile": "../../assets/Serilog.snk"
+    "keyFile": "../../assets/Serilog.snk",
+    "warningsAsErrors": true,
+    "xmlDoc": true
   },
   "frameworks": {
     "net4.5": {
@@ -39,6 +41,7 @@
       },
       "dependencies": {
         "System.Net.Http": "4.1.0",
+        "System.Threading.Thread": "4.0.0",
         "Serilog.Sinks.RollingFile": "3.0.0"
       }
     }

--- a/test/Serilog.Sinks.Seq.Tests/project.json
+++ b/test/Serilog.Sinks.Seq.Tests/project.json
@@ -7,7 +7,8 @@
     "Newtonsoft.Json": "8.0.3"
   },
   "buildOptions": {
-    "keyFile": "../../assets/Serilog.snk"
+    "keyFile": "../../assets/Serilog.snk",
+    "warningsAsErrors": true
   },
   "frameworks": {
     "net4.5.2": { },


### PR DESCRIPTION
Fixes #38.

Also re-enables XML documentation generation, which was lost in the move to .NET Core.