### PR TITLE
3.1.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,42 @@ Seq 3.3 accepts Serilog's more efficient [compact JSON format](https://github.co
 ```csharp
     .WriteTo.Seq("http://localhost:5341", compact: true)
 ```
+
+### Troubleshooting
+
+> Nothing showed up, what can I do?
+
+If events don't appear in Seq after pressing the refresh button in the _filter bar_, either your application was unable to contact the Seq server, or else the Seq server rejected the log events for some reason.
+
+#### Server-side issues
+
+The Seq server may reject incoming events if they're missing a required API key, if the payload is corrupted somehow, or if the log events are too large to accept.
+
+Server-side issues are diagnosed using the Seq _Ingestion Log_, which shows the details of any problems detected on the server side. The ingestion log is linked from the _Settings_ > _Diagnostics_ page in the Seq user interface.
+
+#### Client-side issues
+
+If there's no information in the ingestion log, the application was probably unable to reach the server because of network configuration or connectivity issues. These are reported to the application through Serilog's `SelfLog`.
+
+Add the following line after the logger is configured to print any error information to the console:
+
+```csharp
+Serilog.Debugging.SelfLog.Enable(Console.Error);
+```
+
+If the console is not available, you can pass a delegate into `SelfLog.Enable()` that will be called with each error message:
+
+```csharp
+Serilog.Debugging.SelfLog.Enable(message => {
+    // Do something with `message`
+});
+```
+
+#### Troubleshooting checklist
+
+ * Check the Seq _Ingestion Log_, as described in the _Server-side issues_ section above.
+ * Turn on the Serilog `SelfLog` as described above to check for connectivity problems and other issues on the client side.
+ * Make sure your application calls `Log.CloseAndFlush()`, or disposes the root `Logger`, before it exits - otherwise, buffered events may be lost.
+ * If your app is a Windows console application, it is also important to close the console window by exiting the app; Windows console apps are terminated "hard" if the close button in the title bar is used, so events buffered for sending to Seq may be lost if you use it.
+ * Ask for help on the [Seq support forum](http://docs.getseq.net/discuss) or email **support@getseq.net**.
+ 

--- a/README.md
+++ b/README.md
@@ -125,5 +125,5 @@ Serilog.Debugging.SelfLog.Enable(message => {
  * Turn on the Serilog `SelfLog` as described above to check for connectivity problems and other issues on the client side.
  * Make sure your application calls `Log.CloseAndFlush()`, or disposes the root `Logger`, before it exits - otherwise, buffered events may be lost.
  * If your app is a Windows console application, it is also important to close the console window by exiting the app; Windows console apps are terminated "hard" if the close button in the title bar is used, so events buffered for sending to Seq may be lost if you use it.
- * Ask for help on the [Seq support forum](http://docs.getseq.net/discuss) or email **support@getseq.net**.
+ * [Raise an issue](https://github.com/serilog/serilog-sinks-seq/issues), ask for help on the [Seq support forum](http://docs.getseq.net/discuss) or email **support@getseq.net**.
  

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PM> Install-Package Serilog.Sinks.Seq
 
 Point the logger to Seq:
 
-```powershell
+```csharp
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Seq("http://localhost:5341")
     .CreateLogger();
@@ -80,3 +80,11 @@ Log.Logger = new LoggerConfiguration()
 ```
 
 For further information see the [Seq documentation](http://docs.getseq.net/docs/using-serilog#dynamic-level-control).
+
+### Compact event format
+
+Seq 3.3 accepts Serilog's more efficient [compact JSON format](https://github.com/serilog/serilog-formatting-compact/). To use this, configure the sink with `compact: true`:
+
+```csharp
+    .WriteTo.Seq("http://localhost:5341", compact: true)
+```

--- a/sample/Sample/Program.cs
+++ b/sample/Sample/Program.cs
@@ -23,7 +23,7 @@ namespace Sample
 
             Log.Information("Sample starting up");
 
-            foreach (var i in Enumerable.Range(0, 1000))
+            foreach (var i in Enumerable.Range(0, 10))
             {
                 Log.Information("Running loop {Counter}", i);
 

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/ControlledLevelSwitch.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/ControlledLevelSwitch.cs
@@ -1,0 +1,73 @@
+﻿// Serilog.Sinks.Seq Copyright 2016 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Sinks.Seq
+{
+    /// <summary>
+    /// Instances of this type are single-threaded, generally only updated on a background
+    /// timer thread. An exception is <see cref="IsIncluded(LogEvent)"/>, which may be called
+    /// concurrently but performs no synchronization.
+    /// </summary>
+    class ControlledLevelSwitch
+    {
+        // If non-null, then background level checks will be performed; set either through the constructor
+        // or in response to a level specification from the server. Never set to null after being made non-null.
+        LoggingLevelSwitch _controlledSwitch;
+        LogEventLevel? _originalLevel;
+
+        public ControlledLevelSwitch(LoggingLevelSwitch controlledSwitch = null)
+        {
+            _controlledSwitch = controlledSwitch;
+        }
+
+        public bool IsActive => _controlledSwitch != null;
+
+        public bool IsIncluded(LogEvent evt)
+        {
+            // Concurrent, but not synchronized.
+            var controlledSwitch = _controlledSwitch;
+            return controlledSwitch == null ||
+                (int)controlledSwitch.MinimumLevel <= (int)evt.Level;
+        }
+
+        public void Update(LogEventLevel? minimumAcceptedLevel)
+        {
+            if (minimumAcceptedLevel == null)
+            {
+                if (_controlledSwitch != null && _originalLevel.HasValue)
+                    _controlledSwitch.MinimumLevel = _originalLevel.Value;
+
+                return;
+            }
+
+            if (_controlledSwitch == null)
+            {
+                // The server is controlling the logging level, but not the overall logger. Hence, if the server
+                // stops controlling the level, the switch should become transparent.
+                _originalLevel = LevelAlias.Minimum;
+                _controlledSwitch = new LoggingLevelSwitch(minimumAcceptedLevel.Value);
+                return;
+            }
+
+            if (!_originalLevel.HasValue)
+                _originalLevel = _controlledSwitch.MinimumLevel;
+
+            _controlledSwitch.MinimumLevel = minimumAcceptedLevel.Value;
+        }
+    }
+}

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/DurableSeqSink.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/DurableSeqSink.cs
@@ -72,9 +72,7 @@ namespace Serilog.Sinks.Seq
         {
             // This is a lagging indicator, but the network bandwidth usage benefits
             // are worth the ambiguity.
-            var minimumAcceptedLevel = _shipper.MinimumAcceptedLevel;
-            if (minimumAcceptedLevel == null ||
-                (int)minimumAcceptedLevel <= (int)logEvent.Level)
+            if (_shipper.IsIncluded(logEvent))
             {
                 _sink.Emit(logEvent);
             }

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/HttpLogShipper.cs
@@ -19,7 +19,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using Serilog.Core;
@@ -28,6 +27,10 @@ using Serilog.Events;
 using IOFile = System.IO.File;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+
+#if HRESULTS
+using System.Runtime.InteropServices;
+#endif
 
 namespace Serilog.Sinks.Seq
 {
@@ -394,6 +397,7 @@ namespace Serilog.Sinks.Seq
                     return fileStream.Length <= maxLen;
                 }
             }
+#if HRESULTS
             catch (IOException ex)
             {
                 var errorCode = Marshal.GetHRForException(ex) & ((1 << 16) - 1);
@@ -402,6 +406,12 @@ namespace Serilog.Sinks.Seq
                     SelfLog.WriteLine("Unexpected I/O exception while testing locked status of {0}: {1}", file, ex);
                 }
             }
+#else
+            catch (IOException)
+            {
+                // Where no HRESULT is available, assume IOExceptions indicate a locked file
+            }
+#endif
             catch (Exception ex)
             {
                 SelfLog.WriteLine("Unexpected exception while testing locked status of {0}: {1}", file, ex);

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/SeqSink.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/SeqSink.cs
@@ -30,22 +30,20 @@ namespace Serilog.Sinks.Seq
 {
     class SeqSink : PeriodicBatchingSink
     {
-        readonly string _apiKey;
-        readonly long? _eventBodyLimitBytes;
-        readonly HttpClient _httpClient;
-
-        static readonly JsonValueFormatter JsonValueFormatter = new JsonValueFormatter();
-
-        // If non-null, then background level checks will be performed; set either through the constructor
-        // or in response to a level specification from the server. Never set to null after being made non-null.
-        LoggingLevelSwitch _levelControlSwitch;
-        readonly bool _useCompactFormat;
-        static readonly TimeSpan RequiredLevelCheckInterval = TimeSpan.FromMinutes(2);
-        DateTime _nextRequiredLevelCheckUtc = DateTime.UtcNow.Add(RequiredLevelCheckInterval);
-
         public const int DefaultBatchPostingLimit = 1000;
         public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(2);
         public const int DefaultQueueSizeLimit = 100000;
+
+        static readonly TimeSpan RequiredLevelCheckInterval = TimeSpan.FromMinutes(2);
+        static readonly JsonValueFormatter JsonValueFormatter = new JsonValueFormatter();
+
+        readonly string _apiKey;
+        readonly long? _eventBodyLimitBytes;
+        readonly HttpClient _httpClient;
+        readonly bool _useCompactFormat;
+
+        DateTime _nextRequiredLevelCheckUtc = DateTime.UtcNow.Add(RequiredLevelCheckInterval);
+        ControlledLevelSwitch _controlledSwitch;
 
         public SeqSink(
             string serverUrl,
@@ -62,7 +60,7 @@ namespace Serilog.Sinks.Seq
             if (serverUrl == null) throw new ArgumentNullException(nameof(serverUrl));
             _apiKey = apiKey;
             _eventBodyLimitBytes = eventBodyLimitBytes;
-            _levelControlSwitch = levelControlSwitch;
+            _controlledSwitch = new ControlledLevelSwitch(levelControlSwitch);
             _useCompactFormat = useCompactFormat;
             _httpClient = messageHandler != null ? new HttpClient(messageHandler) : new HttpClient();
             _httpClient.BaseAddress = new Uri(SeqApi.NormalizeServerBaseAddress(serverUrl));
@@ -80,7 +78,7 @@ namespace Serilog.Sinks.Seq
         // configured to set a specific level, before background level checks will be performed.
         protected override void OnEmptyBatch()
         {
-            if (_levelControlSwitch != null &&
+            if (_controlledSwitch.IsActive &&
                 _nextRequiredLevelCheckUtc < DateTime.UtcNow)
             {
                 EmitBatch(Enumerable.Empty<LogEvent>());
@@ -112,19 +110,7 @@ namespace Serilog.Sinks.Seq
                 throw new LoggingFailedException($"Received failed result {result.StatusCode} when posting events to Seq");
 
             var returned = await result.Content.ReadAsStringAsync();
-            var minimumAcceptedLevel = SeqApi.ReadEventInputResult(returned);
-            if (minimumAcceptedLevel == null)
-            {
-                if (_levelControlSwitch != null)
-                    _levelControlSwitch.MinimumLevel = LevelAlias.Minimum;
-            }
-            else
-            {
-                if (_levelControlSwitch == null)
-                    _levelControlSwitch = new LoggingLevelSwitch(minimumAcceptedLevel.Value);
-                else
-                    _levelControlSwitch.MinimumLevel = minimumAcceptedLevel.Value;
-            }
+            _controlledSwitch.Update(SeqApi.ReadEventInputResult(returned));
         }
 
         internal static string FormatCompactPayload(IEnumerable<LogEvent> events, long? eventBodyLimitBytes)
@@ -190,9 +176,7 @@ namespace Serilog.Sinks.Seq
 
         protected override bool CanInclude(LogEvent evt)
         {
-            var levelControlSwitch = _levelControlSwitch;
-            return levelControlSwitch == null ||
-                (int)levelControlSwitch.MinimumLevel <= (int)evt.Level;
+            return _controlledSwitch.IsIncluded(evt);
         }
 
         static bool CheckEventBodySize(string json, long? eventBodyLimitBytes)

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/SeqSink.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/SeqSink.cs
@@ -45,6 +45,7 @@ namespace Serilog.Sinks.Seq
 
         public const int DefaultBatchPostingLimit = 1000;
         public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(2);
+        public const int DefaultQueueSizeLimit = 100000;
 
         public SeqSink(
             string serverUrl,
@@ -54,8 +55,9 @@ namespace Serilog.Sinks.Seq
             long? eventBodyLimitBytes,
             LoggingLevelSwitch levelControlSwitch,
             HttpMessageHandler messageHandler,
-            bool useCompactFormat)
-            : base(batchPostingLimit, period)
+            bool useCompactFormat,
+            int queueSizeLimit)
+            : base(batchPostingLimit, period, queueSizeLimit)
         {
             if (serverUrl == null) throw new ArgumentNullException(nameof(serverUrl));
             _apiKey = apiKey;

--- a/src/Serilog.Sinks.Seq/project.json
+++ b/src/Serilog.Sinks.Seq/project.json
@@ -1,9 +1,9 @@
 {
-  "version": "3.0.2-*",
-  "description": "Serilog sink that writes to the Seq event server over HTTP/S.",
+  "version": "3.1.0-*",
+  "description": "Serilog sink that writes to the Seq log server over HTTP/S.",
   "authors": [ "Serilog Contributors" ],
   "packOptions": {
-    "tags": [ "serilog", "seq", "structured logging" ],
+    "tags": [ "serilog", "seq" ],
     "projectUrl": "https://github.com/serilog/serilog-sinks-seq",
     "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
     "iconUrl": "http://serilog.net/images/serilog-sink-seq-nuget.png"
@@ -21,7 +21,7 @@
   "frameworks": {
     "net4.5": {
       "buildOptions": {
-        "define": [ "DURABLE", "WAITABLE_TIMER", "HRESULTS" ]
+        "define": [ "DURABLE", "THREADING_TIMER", "HRESULTS" ]
       },
       "frameworkAssemblies": {
         "System.Net.Http": ""
@@ -37,12 +37,12 @@
     },
     "netstandard1.3": {
       "buildOptions": {
-        "define": [ "DURABLE" ]
+        "define": [ "DURABLE", "THREADING_TIMER" ]
       },
       "dependencies": {
         "System.Net.Http": "4.1.0",
-        "System.Threading.Thread": "4.0.0",
-        "Serilog.Sinks.RollingFile": "3.0.0"
+        "Serilog.Sinks.RollingFile": "3.0.0",
+        "System.Threading.Timer": "4.0.1"
       }
     }
   }

--- a/src/Serilog.Sinks.Seq/project.json
+++ b/src/Serilog.Sinks.Seq/project.json
@@ -19,7 +19,7 @@
   "frameworks": {
     "net4.5": {
       "buildOptions": {
-        "define": [ "DURABLE", "WAITABLE_TIMER" ]
+        "define": [ "DURABLE", "WAITABLE_TIMER", "HRESULTS" ]
       },
       "frameworkAssemblies": {
         "System.Net.Http": ""

--- a/src/Serilog.Sinks.Seq/project.json
+++ b/src/Serilog.Sinks.Seq/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0-*",
+  "version": "3.0.1-*",
   "description": "Serilog sink that writes to the Seq event server over HTTP/S.",
   "authors": [ "Serilog Contributors" ],
   "packOptions": {

--- a/src/Serilog.Sinks.Seq/project.json
+++ b/src/Serilog.Sinks.Seq/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.1-*",
+  "version": "3.0.2-*",
   "description": "Serilog sink that writes to the Seq event server over HTTP/S.",
   "authors": [ "Serilog Contributors" ],
   "packOptions": {

--- a/src/Serilog.Sinks.Seq/project.json
+++ b/src/Serilog.Sinks.Seq/project.json
@@ -9,7 +9,7 @@
     "iconUrl": "http://serilog.net/images/serilog-sink-seq-nuget.png"
   },
   "dependencies": {
-    "Serilog": "2.2.0-dev-00688",
+    "Serilog": "2.2.0",
     "Serilog.Sinks.PeriodicBatching": "2.0.0",
     "Serilog.Formatting.Compact": "1.0.0"
   },

--- a/src/Serilog.Sinks.Seq/project.json
+++ b/src/Serilog.Sinks.Seq/project.json
@@ -10,11 +10,13 @@
   },
   "dependencies": {
     "Serilog": "2.2.0",
-    "Serilog.Sinks.PeriodicBatching": "2.0.0",
+    "Serilog.Sinks.PeriodicBatching": "2.1.0",
     "Serilog.Formatting.Compact": "1.0.0"
   },
   "buildOptions": {
-    "keyFile": "../../assets/Serilog.snk"
+    "keyFile": "../../assets/Serilog.snk",
+    "warningsAsErrors": true,
+    "xmlDoc": true
   },
   "frameworks": {
     "net4.5": {
@@ -39,6 +41,7 @@
       },
       "dependencies": {
         "System.Net.Http": "4.1.0",
+        "System.Threading.Thread": "4.0.0",
         "Serilog.Sinks.RollingFile": "3.0.0"
       }
     }

--- a/src/Serilog.Sinks.Seq/project.json
+++ b/src/Serilog.Sinks.Seq/project.json
@@ -25,7 +25,7 @@
         "System.Net.Http": ""
       },
       "dependencies": {
-        "Serilog.Sinks.RollingFile": "2.0.0"
+        "Serilog.Sinks.RollingFile": "3.0.0"
       }
     },
     "netstandard1.1": {
@@ -39,7 +39,7 @@
       },
       "dependencies": {
         "System.Net.Http": "4.1.0",
-        "Serilog.Sinks.RollingFile": "2.0.0"
+        "Serilog.Sinks.RollingFile": "3.0.0"
       }
     }
   }

--- a/test/Serilog.Sinks.Seq.Tests/ControlledLevelSwitchTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/ControlledLevelSwitchTests.cs
@@ -1,0 +1,90 @@
+﻿using Serilog.Core;
+using Serilog.Events;
+using Serilog.Sinks.Seq.Tests.Support;
+using Xunit;
+
+namespace Serilog.Sinks.Seq.Tests
+{
+    public class ControlledLevelSwitchTests
+    {
+        [Fact]
+        public void WhenTheServerSendsALevelTheSwitchIsAdjusted()
+        {
+            var lls = new LoggingLevelSwitch(LogEventLevel.Warning);
+            var cls = new ControlledLevelSwitch(lls);
+            cls.Update(LogEventLevel.Debug);
+            Assert.Equal(LogEventLevel.Debug, lls.MinimumLevel);
+        }
+
+        [Fact]
+        public void WhenTheServerSendsNoLevelTheSwitchIsNotInitiallyAdjusted()
+        {
+            var lls = new LoggingLevelSwitch(LogEventLevel.Warning);
+            lls.MinimumLevel = LogEventLevel.Fatal;
+            var cls = new ControlledLevelSwitch(lls);
+            cls.Update(null);
+            Assert.Equal(LogEventLevel.Fatal, lls.MinimumLevel);
+        }
+
+        [Fact]
+        public void WhenTheServerSendsNoLevelTheSwitchIsResetIfPreviouslyAdjusted()
+        {
+            var lls = new LoggingLevelSwitch(LogEventLevel.Warning);
+            var cls = new ControlledLevelSwitch(lls);
+            cls.Update(LogEventLevel.Information);
+            cls.Update(null);
+            Assert.Equal(LogEventLevel.Warning, lls.MinimumLevel);
+        }
+
+        [Fact]
+        public void WithNoSwitchToControlAllEventsAreIncluded()
+        {
+            var cls = new ControlledLevelSwitch(null);
+            Assert.True(cls.IsIncluded(Some.DebugEvent()));
+        }
+
+        [Fact]
+        public void WithNoSwitchToControlEventsAreStillFiltered()
+        {
+            var cls = new ControlledLevelSwitch(null);
+            cls.Update(LogEventLevel.Warning);
+            Assert.True(cls.IsIncluded(Some.ErrorEvent()));
+            Assert.False(cls.IsIncluded(Some.InformationEvent()));
+        }
+
+        [Fact]
+        public void WithNoSwitchToControlAllEventsAreIncludedAfterReset()
+        {
+            var cls = new ControlledLevelSwitch(null);
+            cls.Update(LogEventLevel.Warning);
+            cls.Update(null);
+            Assert.True(cls.IsIncluded(Some.DebugEvent()));
+        }
+
+        [Fact]
+        public void WhenControllingASwitchTheControllerIsActive()
+        {
+            var cls = new ControlledLevelSwitch(new LoggingLevelSwitch());
+            Assert.True(cls.IsActive);
+        }
+
+        [Fact]
+        public void WhenNotControllingASwitchTheControllerIsNotActive()
+        {
+            var cls = new ControlledLevelSwitch();
+            Assert.False(cls.IsActive);
+        }
+
+        [Fact]
+        public void AfterServerControlhTheControllerIsAlwaysActive()
+        {
+            var cls = new ControlledLevelSwitch();
+
+            cls.Update(LogEventLevel.Information);
+            Assert.True(cls.IsActive);
+
+            cls.Update(null);
+            Assert.True(cls.IsActive);
+        }
+    }
+}

--- a/test/Serilog.Sinks.Seq.Tests/Support/Some.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Support/Some.cs
@@ -14,6 +14,11 @@ namespace Serilog.Sinks.Seq.Tests.Support
 
         public static LogEvent LogEvent(Exception exception, string messageTemplate, params object[] propertyValues)
         {
+            return LogEvent(LogEventLevel.Information, exception, messageTemplate, propertyValues);
+        }
+
+        public static LogEvent LogEvent(LogEventLevel level, Exception exception, string messageTemplate, params object[] propertyValues)
+        {
             var log = new LoggerConfiguration().CreateLogger();
             MessageTemplate template;
             IEnumerable<LogEventProperty> properties;
@@ -23,7 +28,22 @@ namespace Serilog.Sinks.Seq.Tests.Support
             {
                 throw new XunitException("Template could not be bound.");
             }
-            return new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, exception, template, properties);
+            return new LogEvent(DateTimeOffset.Now, level, exception, template, properties);
+        }
+
+        public static LogEvent DebugEvent()
+        {
+            return LogEvent(LogEventLevel.Debug, null, "Debug event");
+        }
+
+        public static LogEvent InformationEvent()
+        {
+            return LogEvent(LogEventLevel.Information, null, "Information event");
+        }
+
+        public static LogEvent ErrorEvent()
+        {
+            return LogEvent(LogEventLevel.Error, null, "Error event");
         }
     }
 }

--- a/test/Serilog.Sinks.Seq.Tests/project.json
+++ b/test/Serilog.Sinks.Seq.Tests/project.json
@@ -7,7 +7,8 @@
     "Newtonsoft.Json": "8.0.3"
   },
   "buildOptions": {
-    "keyFile": "../../assets/Serilog.snk"
+    "keyFile": "../../assets/Serilog.snk",
+    "warningsAsErrors": true
   },
   "frameworks": {
     "net4.5.2": { },


### PR DESCRIPTION
 * #33 - don't use `HRESULT` on .NET Core (for Xamarin support)
 * #38 - update `PeriodicBatchingSink` dependency, default to 100k item queue size
 * #40 - package installation on UWP
 * #41 - fix level handling with dynamic level control when server-side is not configured
