### PR TITLE
Update declared dependencies to pull in file sink bug fix

### DIFF
--- a/src/Serilog.Sinks.Seq/project.json
+++ b/src/Serilog.Sinks.Seq/project.json
@@ -9,7 +9,7 @@
     "iconUrl": "http://serilog.net/images/serilog-sink-seq-nuget.png"
   },
   "dependencies": {
-    "Serilog": "2.2.0",
+    "Serilog": "2.3.0",
     "Serilog.Sinks.PeriodicBatching": "2.1.0",
     "Serilog.Formatting.Compact": "1.0.0"
   },
@@ -27,6 +27,7 @@
         "System.Net.Http": ""
       },
       "dependencies": {
+        "Serilog.Sinks.File": "3.1.1",
         "Serilog.Sinks.RollingFile": "3.0.0"
       }
     },
@@ -41,6 +42,7 @@
       },
       "dependencies": {
         "System.Net.Http": "4.1.0",
+        "Serilog.Sinks.File": "3.1.1",
         "Serilog.Sinks.RollingFile": "3.0.0",
         "System.Threading.Timer": "4.0.1"
       }


### PR DESCRIPTION
https://github.com/serilog/serilog-sinks-file/issues/23 resulted in durable log shipping failing if `fileSizeLimitBytes` was also specified.

PR forces dependency on _Serilog.Sinks.File_ 3.1.1, which includes the fix. Pushed the Serilog dependency version forward also.