### PR TITLE
3.2.0 Release

### DIFF
--- a/src/Serilog.Sinks.Seq/project.json
+++ b/src/Serilog.Sinks.Seq/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.1.0-*",
+  "version": "3.1.1-*",
   "description": "Serilog sink that writes to the Seq log server over HTTP/S.",
   "authors": [ "Serilog Contributors" ],
   "packOptions": {

--- a/src/Serilog.Sinks.Seq/project.json
+++ b/src/Serilog.Sinks.Seq/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.1.1-*",
+  "version": "3.1.2-*",
   "description": "Serilog sink that writes to the Seq log server over HTTP/S.",
   "authors": [ "Serilog Contributors" ],
   "packOptions": {

--- a/src/Serilog.Sinks.Seq/project.json
+++ b/src/Serilog.Sinks.Seq/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.1.2-*",
+  "version": "3.2.0-*",
   "description": "Serilog sink that writes to the Seq log server over HTTP/S.",
   "authors": [ "Serilog Contributors" ],
   "packOptions": {
@@ -27,8 +27,8 @@
         "System.Net.Http": ""
       },
       "dependencies": {
-        "Serilog.Sinks.File": "3.1.1",
-        "Serilog.Sinks.RollingFile": "3.0.0"
+        "Serilog.Sinks.File": "3.2.0",
+        "Serilog.Sinks.RollingFile": "3.3.0"
       }
     },
     "netstandard1.1": {
@@ -42,8 +42,8 @@
       },
       "dependencies": {
         "System.Net.Http": "4.1.0",
-        "Serilog.Sinks.File": "3.1.1",
-        "Serilog.Sinks.RollingFile": "3.0.0",
+        "Serilog.Sinks.File": "3.2.0",
+        "Serilog.Sinks.RollingFile": "3.3.0",
         "System.Threading.Timer": "4.0.1"
       }
     }


### PR DESCRIPTION
 * https://github.com/serilog/serilog-sinks-file/issues/23 via #47 - fix durable log shipping with `fileSizeLimitBytes` declared

