### PR TITLE
Version the sink assembly along with the package version

### DIFF
--- a/src/Serilog.Sinks.Seq/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.Seq/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-
-[assembly: AssemblyVersion("3.0.0.0")]
+﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Serilog.Sinks.Seq.Tests, PublicKey=" +
                               "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +

--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Serilog sink that writes to the Seq log server over HTTP/HTTPS.</Description>
@@ -17,7 +17,7 @@
     <PackageIconUrl>https://serilog.net/images/serilog-sink-seq-nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/serilog/serilog-sinks-seq</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">


### PR DESCRIPTION
Fixes #63 

This change will use the (non-suffixed) package version as the assembly version, so that we're always moving forwards.