### PR TITLE
Update PeriodicBatchingSink dependency to fix retry window

### DIFF
--- a/sample/Sample/Program.cs
+++ b/sample/Sample/Program.cs
@@ -23,7 +23,7 @@ namespace Sample
 
             Log.Information("Sample starting up");
 
-            foreach (var i in Enumerable.Range(0, 10))
+            foreach (var i in Enumerable.Range(0, 1000))
             {
                 Log.Information("Running loop {Counter}", i);
 

--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Serilog sink that writes to the Seq log server over HTTP/HTTPS.</Description>
@@ -34,7 +34,7 @@
   
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.3.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Brings in https://github.com/serilog/serilog-sinks-periodicbatching/pull/18, to make the failure retry window 10 minutes rather than 40 seconds.