### PR TITLE
3.3.2 Release

### DIFF
--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Serilog sink that writes to the Seq log server over HTTP/HTTPS.</Description>
-    <VersionPrefix>3.3.1</VersionPrefix>
+    <VersionPrefix>3.3.2</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <Copyright>Copyright © Serilog Contributors 2013-2017</Copyright>
     <TargetFrameworks>netstandard1.1;netstandard1.3;net45;net46</TargetFrameworks>


### PR DESCRIPTION
 * #71 - update _Serilog.Sinks.PeriodicBatching_ dependency to bring in fix for batch-retry (extends the retry window to 10 minutes by default)
