### PR TITLE
Consistently use `*Async()` methods so that background level checks occur

### DIFF
--- a/sample/Sample/Program.cs
+++ b/sample/Sample/Program.cs
@@ -17,7 +17,7 @@ namespace Sample
                 .MinimumLevel.ControlledBy(levelSwitch)
                 .WriteTo.LiterateConsole()
                 .WriteTo.Seq("http://localhost:5341",
-                             apiKey: "yeEZyL3SMcxEKUijBjN",
+                             apiKey: "o6nYf3WWnzF43Uu5PZWJ",
                              controlLevelSwitch: levelSwitch)
                 .CreateLogger();
 
@@ -25,7 +25,7 @@ namespace Sample
 
             foreach (var i in Enumerable.Range(0, 1000))
             {
-                Log.Information("Running loop {Counter}", i);
+                Log.Information("Running loop {Counter}, switch is at {Level}", i, levelSwitch.MinimumLevel);
 
                 Thread.Sleep(1000);
                 Log.Debug("Loop iteration done");

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/SeqSink.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/SeqSink.cs
@@ -76,12 +76,12 @@ namespace Serilog.Sinks.Seq
 
         // The sink must emit at least one event on startup, and the server be
         // configured to set a specific level, before background level checks will be performed.
-        protected override void OnEmptyBatch()
+        protected override async Task OnEmptyBatchAsync()
         {
             if (_controlledSwitch.IsActive &&
                 _nextRequiredLevelCheckUtc < DateTime.UtcNow)
             {
-                EmitBatch(Enumerable.Empty<LogEvent>());
+                await EmitBatchAsync(Enumerable.Empty<LogEvent>());
             }
         }
 


### PR DESCRIPTION
Fixes #75.