### PR TITLE
5.0.1 Release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ artifacts:
 deploy:
 - provider: NuGet
   api_key:
-    secure: RvDIxqzjq8qHsdFmR0SEZ/74b/1NsOaRUxDioL9MqtjrETHCATtygFexwefkn8rS
+    secure: K6TcIFIyxBcDuZ5DL7bJC+fGwDo458q0SDh+ybLujGTddA/voxg2FMUtJQ7rTEbt
   skip_symbols: true
   on:
     branch: /^(main|dev)$/

--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Serilog sink that writes to the Seq log server over HTTP/HTTPS.</Description>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.0.1</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <Copyright>Copyright © Serilog Contributors</Copyright>
     <TargetFrameworks>netstandard1.1;netstandard1.3;net45;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>


### PR DESCRIPTION
 * #147 - update _System.Net.Http_ for `netstandard1.1` and `netstandard1.3` (avoids [CVE-2018-8292](https://github.com/advisories/GHSA-7jgj-8wvc-jh57))
